### PR TITLE
Versioning scheme and documentation for initial release

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Tablesaw parquet I/O
 
 ## Overview
 
-__tablesaw-parquet__  is a [parquet](https://parquet.apache.org/) reader and writer for the [Tablesaw](https://github.com/jtablesaw/tablesaw) project implemented using [parquet-mr](https://github.com/apache/parquet-mr).
+__tablesaw-parquet__  is an [Apache Parquet](https://parquet.apache.org/) reader and writer for the [Tablesaw](https://github.com/jtablesaw/tablesaw) project implemented using [parquet-mr](https://github.com/apache/parquet-mr).
 
 ## Versioning
 
@@ -27,8 +27,8 @@ __maven:__
 
 ```xml
 <properties>
-    <tablesaw.version>TABLESAW_VERSION</tablesaw.version>
-    <tablesaw-parquet.version>TABLESAW-PARQUET_VERSION</tablesaw-parquet.version>
+    <tablesaw.version>0.38.2</tablesaw.version>
+    <tablesaw-parquet.version>0.7.0-SNAPSHOT</tablesaw-parquet.version>
 </properties>
 <dependencies>
   <dependency>
@@ -47,7 +47,19 @@ __maven:__
 __gradle:__
 
 ```
-TODO
+...
+
+ext {
+    tablesawVersion = "0.38.2"
+    tablesawParquetVersion = "0.7.0-SNAPSHOT"
+}
+
+dependencies {
+    implementation("tech.tablesaw:tablesaw-core:${tablesawVersion}")
+    implementation("net.tlabs-data:tablesaw_${tablesawVersion}-parquet:${tablesawParquetVersion}")
+}
+
+...
 ```
 
 Read and write your parquet file as a  __tablesaw__  Table using the following idiom:
@@ -91,7 +103,7 @@ Annotated [parquet logical types](https://github.com/apache/parquet-format/blob/
 | BSON |  __Not read__  |  __Not tested__  |
 | Nested Types | TextColumn | Textual representation of the nested type, see *withManageGroupsAs* option |
 
-Parquet also handles repeated fields (multiple values for the same field), we handle these as the Nested Types: by default a string representation of the repeated fields is stored in a TextColumn. The same *withManageGroupsAs* option is used to change this behavior.
+Parquet also supports repeated fields (multiple values for the same field); we handle these as the Nested Types: by default a string representation of the repeated fields is stored in a TextColumn. The same *withManageGroupsAs* option is used to change this behavior.
 
 Due to the lack of parquet files for testing, some logical type conversion are currently not tested (INTERVAL, UUID, BSON).
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Tablesaw parquet I/O
 
 ## Overview
 
-__tablesaw-parquet__  is a [parquet](https://github.com/apache/parquet-mr) reader and writer for the [Tablesaw](https://github.com/jtablesaw/tablesaw) project.
+__tablesaw-parquet__  is a [parquet](https://parquet.apache.org/) reader and writer for the [Tablesaw](https://github.com/jtablesaw/tablesaw) project implemented using [parquet-mr](https://github.com/apache/parquet-mr).
 
 ## Versioning
 
@@ -58,19 +58,111 @@ Table table = new TablesawParquetReader().read(TablesawParquetReadOptions.builde
 
 ## Data type conversion
 
+#### When reading a parquet file (parquet to tablesaw)
 
+Non-annotated [parquet data types](https://github.com/apache/parquet-format) are converted to  __tablesaw__  column types as follow:
+
+| Parquet type | Tablesaw column type | Notes |
+|--------------|----------------------|-------|
+| BOOLEAN  | BooleanColumn |  |
+| INT32 | IntColumn |  |
+| INT64 | LongColumn |  |
+| INT96 | StringColumn (default) or InstantColumn | Managed by the *convertInt96ToTimestamp* option |
+| FLOAT | DoubleColumn (default) or FloatColumn | Managed by the *minimizeColumnSizes* option |
+| DOUBLE | DoubleColumn |  |
+| BYTE_ARRAY | StringColumn | Managed by the *withUnnanotatedBinaryAs* option |
+
+Annotated [parquet logical types](https://github.com/apache/parquet-format/blob/master/LogicalTypes.md) are converted to  __tablesaw__  column types as follow:
+
+| Parquet logical type | Tablesaw column type | Notes |
+|----------------------|----------------------|-------|
+| STRING  | StringColumn |  |
+| ENUM | StringColumn |  |
+| UUID | StringColumn | *Not formatted as a UUID*  __Not tested__  |
+| Signed Integers | ShortColumn or IntColumn or LongColumn | ShortColumn only with the *minimizeColumnSizes* option |
+| Unsigned Integers  | ShortColumn or IntColumn or LongColumn | ShortColumn only with the *minimizeColumnSizes* option |
+| DECIMAL | DoubleColumn |  |
+| DATE | DateColumn |  |
+| TIME | TimeColumn |  |
+| TIMESTAMP | DateTimeColumn or InstantColumn | Timestamps normalized to UTC are converted to Instant, others as LocalDateTime |
+| INTERVAL | StringColumn | ISO String representation of the interval  __Not tested__  |
+| JSON | TextColumn |  |
+| BSON |  __Not read__  |  __Not tested__  |
+| Nested Types | TextColumn | Textual representation of the nested type, see *withManageGroupsAs* option |
+
+Parquet also handles repeated fields (multiple values for the same field), we handle these as the Nested Types: by default a string representation of the repeated fields is stored in a TextColumn. The same *withManageGroupsAs* option is used to change this behavior.
+
+Due to the lack of parquet files for testing, some logical type conversion are currently not tested (INTERVAL, UUID, BSON).
+
+Keep in mind that all tablesaw columns storing time (TimeColumn, DateTimeColumn and InstantColumn) use MILLIS precision, if read from a parquet file with better time precision (MICROS or NANOS) the values will be truncated (in the current tablesaw implementation).
+
+#### When writing a parquet file (tablesaw to parquet)
+
+| Tablesaw column type | Parquet type (logical type) | Notes |
+|----------------------|-----------------------------|-------|
+| BooleanColumn | BOOLEAN |  |
+| ShortColumn | INT32 (Integer: 16 bits, signed)|  |
+| IntColumn | INT32 |  |
+| LongColumn | INT64 |  |
+| FloatColumn | FLOAT |  |
+| DoubleColumn | DOUBLE |  |
+| StringColumn | BINARY (STRING) |  |
+| TextColumn | BINARY (STRING) |  |
+| TimeColumn | INT64 (TIME: NANOS, not UTC) | *Will likely change to INT32 MILLIS in a future release* |
+| DateColumn | INT32 (DATE) |  |
+| DateTimeColumn | INT64 (TIMESTAMP: MILLIS, not UTC) |  |
+| InstantColumn | INT64 (TIMESTAMP: MILLIS, UTC) |  |
+
+Note that a tablesaw Table written to parquet and read back will have the following changes:
+
+* TextColumns will be read back as StringColumns.
+* If the *minimizeColumnSizes* option is not set (which is the default), Floats will be changed to Doubles and Shorts to Integers.
 
 ## Features
 
-### Implemented features
+#### Column encoding
 
+Physical reading and writing of parquet files is done by [parquet-mr](https://github.com/apache/parquet-mr). The encoding and decoding is managed by this library.
 
+#### Compression codecs
 
-### Implemented but not tested features
+Currently supported and tested compression codecs: UNCOMPRESSED (None), SNAPPY, GZIP, and ZSTD.
 
-### Not implemented features
+Other compression codecs *might* work when reading parquet files depending on your setup but there is no guarantee.
 
-### Roadmap
+#### Predicate pushdown
 
-## Contributing
+Predicate pushdown is not supported when reading parquet files.
 
+Parquet files written with tablesaw-parquet contain the statistics needed for predicate pushdown when reading files with other parquet readers.
+
+#### Encryption
+
+[Parquet Modular Encryption](https://github.com/apache/parquet-format/blob/encryption/Encryption.md) is not supported.
+
+#### Column filtering
+
+Additional options for filtering columns based on name or type will be added in the future.
+
+## Compatibility testing
+
+Testing the compatibility with other sources of parquet files is paramount. We currently use two sets of test files for that:
+
+* Test files from the [parquet-testing](https://github.com/apache/parquet-testing) project
+* Test files generated from [pandas](https://pandas.pydata.org/) dataframe with both [fastparquet](https://fastparquet.readthedocs.io/en/latest/) and [pyArrow](https://pyarrow.readthedocs.io/en/latest/)
+
+Note that we currently do not run the tests on Windows (see this [github issue](https://github.com/tlabs-data/tablesaw-parquet/issues/3) for details).
+
+## How To Contribute
+
+Users are welcome to contribute to this project.
+
+Bugs or problems with the library should be reported on [github](https://github.com/tlabs-data/tablesaw-parquet/issues). If you report an issue you have when reading a parquet file, please attach a sample test file so we can reproduce and correct the issue. Feature requests are also welcome, but there is no guarantee we will be able to implement them quickly...
+
+Users are also welcome to contribute (small) test parquet files from different sources or with different column types than the ones currently tested. In this case please provide a quick description of the file content and origin. If you are able to provide a pull request with the tests implemented all the better.
+
+We also accept pull requests with code or documentation improvements. We prefer pull requests linked to an existing issue, create one if needed. Code quality is important, code efficiency is even more important, and testing is mandatory.
+
+## Code of conduct
+
+We do not yet have an official code of conduct. In the meantime, be nice to each others (and to the developers).

--- a/README.md
+++ b/README.md
@@ -50,10 +50,11 @@ __gradle:__
 TODO
 ```
 
-Read your parquet file as a  __tablesaw__  Table using the following idiom:
+Read and write your parquet file as a  __tablesaw__  Table using the following idiom:
 
 ```java
 Table table = new TablesawParquetReader().read(TablesawParquetReadOptions.builder(FILENAME).build());
+new TablesawParquetWriter().write(table, TablesawParquetWriteOptions.builder(FILENAME).build());
 ```
 
 ## Data type conversion

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ __maven:__
     <tablesaw.version>0.38.2</tablesaw.version>
     <tablesaw-parquet.version>0.7.0</tablesaw-parquet.version>
 </properties>
+
 <dependencies>
   <dependency>
     <groupId>tech.tablesaw</groupId>
@@ -46,9 +47,7 @@ __maven:__
 
 __gradle:__
 
-```
-...
-
+```json
 ext {
     tablesawVersion = "0.38.2"
     tablesawParquetVersion = "0.7.0"
@@ -58,8 +57,6 @@ dependencies {
     implementation("tech.tablesaw:tablesaw-core:${tablesawVersion}")
     implementation("net.tlabs-data:tablesaw_${tablesawVersion}-parquet:${tablesawParquetVersion}")
 }
-
-...
 ```
 
 Read and write your parquet file as a  __tablesaw__  Table using the following idiom:

--- a/README.md
+++ b/README.md
@@ -78,14 +78,14 @@ Annotated [parquet logical types](https://github.com/apache/parquet-format/blob/
 |----------------------|----------------------|-------|
 | STRING  | StringColumn |  |
 | ENUM | StringColumn |  |
-| UUID | StringColumn | *Not formatted as a UUID*  __Not tested__  |
+| UUID | StringColumn | *Not formatted as a UUID.*  __Not tested__  |
 | Signed Integers | ShortColumn or IntColumn or LongColumn | ShortColumn only with the *minimizeColumnSizes* option |
 | Unsigned Integers  | ShortColumn or IntColumn or LongColumn | ShortColumn only with the *minimizeColumnSizes* option |
 | DECIMAL | DoubleColumn |  |
 | DATE | DateColumn |  |
 | TIME | TimeColumn |  |
 | TIMESTAMP | DateTimeColumn or InstantColumn | Timestamps normalized to UTC are converted to Instant, others as LocalDateTime |
-| INTERVAL | StringColumn | ISO String representation of the interval  __Not tested__  |
+| INTERVAL | StringColumn | ISO String representation of the interval.  __Not tested__  |
 | JSON | TextColumn |  |
 | BSON |  __Not read__  |  __Not tested__  |
 | Nested Types | TextColumn | Textual representation of the nested type, see *withManageGroupsAs* option |
@@ -108,7 +108,7 @@ Keep in mind that all tablesaw columns storing time (TimeColumn, DateTimeColumn 
 | DoubleColumn | DOUBLE |  |
 | StringColumn | BINARY (STRING) |  |
 | TextColumn | BINARY (STRING) |  |
-| TimeColumn | INT64 (TIME: NANOS, not UTC) | *Will likely change to INT32 MILLIS in a future release* |
+| TimeColumn | INT64 (TIME: NANOS, not UTC) | *Will change to INT32 MILLIS in a future release* |
 | DateColumn | INT32 (DATE) |  |
 | DateTimeColumn | INT64 (TIMESTAMP: MILLIS, not UTC) |  |
 | InstantColumn | INT64 (TIMESTAMP: MILLIS, UTC) |  |
@@ -165,4 +165,4 @@ We also accept pull requests with code or documentation improvements. We prefer 
 
 ## Code of conduct
 
-We do not yet have an official code of conduct. In the meantime, be nice to each others (and to the developers).
+We do not yet have an official code of conduct. In the meantime, be nice to the developers and to each others.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,66 @@ Tablesaw parquet I/O
 
 __tablesaw-parquet__  is a [parquet](https://github.com/apache/parquet-mr) reader and writer for the [Tablesaw](https://github.com/jtablesaw/tablesaw) project.
 
-## Status
+## Versioning
 
-__tablesaw-parquet__  is currently under development.
+__tablesaw__  and  __tablesaw-parquet__  have different release schedules and versioning schemes. New  __tablesaw-parquet__  features will be available for the most recent *and* for the previous released version of  __tablesaw__ . Older tablesaw releases will not get updates.
+
+The first supported  __tablesaw__  version is  __v0.38.2__ .
+
+__tablesaw-parquet__  follows the [semantic versioning](https://semver.org/) scheme.
+
+## Getting started
+
+Add tablesaw-core and tablesaw-parquet to your project as follows:
+
+__maven:__
+
+```xml
+<properties>
+    <tablesaw.version>TABLESAW_VERSION</tablesaw.version>
+    <tablesaw-parquet.version>TABLESAW-PARQUET_VERSION</tablesaw-parquet.version>
+</properties>
+<dependencies>
+  <dependency>
+    <groupId>tech.tablesaw</groupId>
+    <artifactId>tablesaw-core</artifactId>
+    <version>${tablesaw.version}</version>
+  </dependency>
+  <dependency>
+    <groupId>net.tlabs-data</groupId>
+    <artifactId>tablesaw_${tablesaw.version}-parquet</artifactId>
+    <version>${tablesaw-parquet.version}</version>
+  </dependency>
+<dependencies>
+```
+
+__gradle:__
+
+```
+TODO
+```
+
+Read your parquet file as a  __tablesaw__  Table using the following idiom:
+
+```java
+Table table = new TablesawParquetReader().read(TablesawParquetReadOptions.builder(FILENAME).build());
+```
+
+## Data type conversion
+
+
+
+## Features
+
+### Implemented features
+
+
+
+### Implemented but not tested features
+
+### Not implemented features
+
+### Roadmap
+
+## Contributing
+

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ __maven:__
 ```xml
 <properties>
     <tablesaw.version>0.38.2</tablesaw.version>
-    <tablesaw-parquet.version>0.7.0-SNAPSHOT</tablesaw-parquet.version>
+    <tablesaw-parquet.version>0.7.0</tablesaw-parquet.version>
 </properties>
 <dependencies>
   <dependency>
@@ -51,7 +51,7 @@ __gradle:__
 
 ext {
     tablesawVersion = "0.38.2"
-    tablesawParquetVersion = "0.7.0-SNAPSHOT"
+    tablesawParquetVersion = "0.7.0"
 }
 
 dependencies {

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ __maven:__
 
 __gradle:__
 
-```json
+```groovy
 ext {
     tablesawVersion = "0.38.2"
     tablesawParquetVersion = "0.7.0"

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>net.tlabs-data</groupId>
   <artifactId>tablesaw_${tablesaw.version}-parquet</artifactId>
-  <version>0.9.0</version>
+  <version>0.7.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Tablesaw-Parquet</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,8 +5,8 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>net.tlabs-data</groupId>
-  <artifactId>tablesaw-parquet</artifactId>
-  <version>0.38.2-SNAPSHOT</version>
+  <artifactId>tablesaw_${tablesaw.version}-parquet</artifactId>
+  <version>0.9.0</version>
   <packaging>jar</packaging>
 
   <name>Tablesaw-Parquet</name>
@@ -173,7 +173,7 @@
           <artifactId>maven-release-plugin</artifactId>
           <version>2.5.3</version>
           <configuration>
-            <tagNameFormat>v@{project.version}</tagNameFormat>
+            <tagNameFormat>${tablesaw.version}-v@{project.version}</tagNameFormat>
             <autoVersionSubmodules>true</autoVersionSubmodules>
             <useReleaseProfile>false</useReleaseProfile>
             <releaseProfiles>release</releaseProfiles>

--- a/src/main/java/net/tlabs/tablesaw/parquet/TablesawParquetReader.java
+++ b/src/main/java/net/tlabs/tablesaw/parquet/TablesawParquetReader.java
@@ -29,22 +29,11 @@ import org.slf4j.LoggerFactory;
 import tech.tablesaw.api.Row;
 import tech.tablesaw.api.Table;
 import tech.tablesaw.io.DataReader;
-import tech.tablesaw.io.ReaderRegistry;
 import tech.tablesaw.io.Source;
 
 public class TablesawParquetReader implements DataReader<TablesawParquetReadOptions> {
 
   private static final Logger LOG = LoggerFactory.getLogger(TablesawParquetReader.class);
-
-  private static final TablesawParquetReader INSTANCE = new TablesawParquetReader();
-
-  static {
-    register(Table.defaultReaderRegistry);
-  }
-
-  public static void register(final ReaderRegistry registry) {
-    registry.registerOptions(TablesawParquetReadOptions.class, INSTANCE);
-  }
 
   @Override
   public Table read(final Source source) throws IOException {

--- a/src/main/java/net/tlabs/tablesaw/parquet/TablesawParquetWriter.java
+++ b/src/main/java/net/tlabs/tablesaw/parquet/TablesawParquetWriter.java
@@ -33,21 +33,10 @@ import tech.tablesaw.api.Row;
 import tech.tablesaw.api.Table;
 import tech.tablesaw.io.DataWriter;
 import tech.tablesaw.io.Destination;
-import tech.tablesaw.io.WriterRegistry;
 
 public class TablesawParquetWriter implements DataWriter<TablesawParquetWriteOptions> {
 
   private static final Logger LOG = LoggerFactory.getLogger(TablesawParquetWriter.class);
-
-  private static final TablesawParquetWriter INSTANCE = new TablesawParquetWriter();
-
-  static {
-    register(Table.defaultWriterRegistry);
-  }
-
-  public static void register(final WriterRegistry registry) {
-    registry.registerOptions(TablesawParquetWriteOptions.class, INSTANCE);
-  }
 
   @Override
   public void write(final Table table, final Destination dest) throws IOException {

--- a/src/main/java/net/tlabs/tablesaw/parquet/TablesawReadSupport.java
+++ b/src/main/java/net/tlabs/tablesaw/parquet/TablesawReadSupport.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.hadoop.api.InitContext;
 import org.apache.parquet.hadoop.api.ReadSupport;
 import org.apache.parquet.io.api.RecordMaterializer;
+import org.apache.parquet.schema.LogicalTypeAnnotation.BsonLogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.DateLogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.DecimalLogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.EnumLogicalTypeAnnotation;
@@ -205,6 +206,11 @@ public class TablesawReadSupport extends ReadSupport<Row> {
                                 DecimalLogicalTypeAnnotation decimalLogicalType) {
                               return Optional.of(DoubleColumn.create(name));
                             }
+
+							@Override
+							public Optional<Column<?>> visit(BsonLogicalTypeAnnotation bsonLogicalType) {
+								return null;
+							}
                           }))
               .orElseGet(
                   () ->

--- a/src/main/java/net/tlabs/tablesaw/parquet/TablesawReadSupport.java
+++ b/src/main/java/net/tlabs/tablesaw/parquet/TablesawReadSupport.java
@@ -178,6 +178,16 @@ public class TablesawReadSupport extends ReadSupport<Row> {
           }
           return StringColumn.create(name);
         case BINARY:
+        	// Filtering out BSON
+        	if(Optional.ofNullable(field.getLogicalTypeAnnotation())
+        		.flatMap(a -> a.accept(new LogicalTypeAnnotationVisitor<Boolean>() {
+					@Override
+					public Optional<Boolean> visit(BsonLogicalTypeAnnotation bsonLogicalType) {
+						return Optional.of(Boolean.TRUE);
+					}
+        		})).isPresent()) {
+        		return null;
+        	  }
           return Optional.ofNullable(field.getLogicalTypeAnnotation())
               .flatMap(
                   a ->
@@ -206,11 +216,6 @@ public class TablesawReadSupport extends ReadSupport<Row> {
                                 DecimalLogicalTypeAnnotation decimalLogicalType) {
                               return Optional.of(DoubleColumn.create(name));
                             }
-
-							@Override
-							public Optional<Column<?>> visit(BsonLogicalTypeAnnotation bsonLogicalType) {
-								return null;
-							}
                           }))
               .orElseGet(
                   () ->


### PR DESCRIPTION
Versioning scheme: the artifactId contains the tablesaw version (e.g. tablesaw_0.38.2-parquet for tablesaw v0.38.2). The tablesaw-parquet version is independent.

This allows to make multiple tablesaw-parquet releases for the same tablesaw version, to support multiple tablesaw version concurrently (we will only support the current and previous one).

Current tablesaw-parquet version set to 0.7

Readme updated with basic installation, usage and type conversion information, as well as implemented features and contributing guidelines.

