### PR TITLE
Disable checksum in writer

### DIFF
--- a/src/main/java/net/tlabs/tablesaw/parquet/TablesawParquetWriteOptions.java
+++ b/src/main/java/net/tlabs/tablesaw/parquet/TablesawParquetWriteOptions.java
@@ -33,6 +33,7 @@ public class TablesawParquetWriteOptions extends WriteOptions {
     private final String outputFile;
     private final CompressionCodec compressionCodec;
     private final boolean overwrite;
+    private final boolean writeChecksum;
 
     public static Builder builder(final File file) {
         return new Builder(file.getAbsolutePath());
@@ -47,6 +48,7 @@ public class TablesawParquetWriteOptions extends WriteOptions {
         this.outputFile = builder.outputFile;
         this.compressionCodec = builder.compressionCodec;
         this.overwrite = builder.overwrite;
+        this.writeChecksum = builder.writeChecksum;
     }
 
     public String getOutputFile() {
@@ -61,11 +63,16 @@ public class TablesawParquetWriteOptions extends WriteOptions {
         return overwrite;
     }
 
+    public boolean isWriteChecksum() {
+        return writeChecksum;
+    }
+
     public static class Builder extends WriteOptions.Builder {
 
         private final String outputFile;
         private CompressionCodec compressionCodec = CompressionCodec.SNAPPY;
         private boolean overwrite = true;
+        private boolean writeChecksum = false;
 
         public Builder(final String outputFile) {
             super((Writer) null);
@@ -79,6 +86,11 @@ public class TablesawParquetWriteOptions extends WriteOptions {
 
         public Builder withOverwrite(final boolean overwrite) {
             this.overwrite = overwrite;
+            return this;
+        }
+
+        public Builder withWriteChecksum(final boolean writeChecksum) {
+            this.writeChecksum = writeChecksum;
             return this;
         }
 

--- a/src/main/java/net/tlabs/tablesaw/parquet/TablesawParquetWriter.java
+++ b/src/main/java/net/tlabs/tablesaw/parquet/TablesawParquetWriter.java
@@ -51,9 +51,16 @@ public class TablesawParquetWriter implements DataWriter<TablesawParquetWriteOpt
 
     @Override
     public void write(final Table table, final TablesawParquetWriteOptions options) {
+//        try {
+//            org.apache.hadoop.fs.FileSystem fs = org.apache.hadoop.fs.FileSystem.getLocal(new Configuration());
+//            fs.setWriteChecksum(false);
+//        } catch (IOException e1) {
+//            // TODO Auto-generated catch block
+//            e1.printStackTrace();
+//        }
         try (final ParquetWriter<Row> writer = new Builder(new Path(options.getOutputFile()), table)
                 .withCompressionCodec(CompressionCodecName.fromConf(options.getCompressionCodec().name()))
-                .withWriteMode(options.isOverwrite() ? Mode.OVERWRITE : Mode.CREATE)
+                .withWriteMode(options.isOverwrite() ? Mode.OVERWRITE : Mode.CREATE).withValidation(false)
                 .build()) {
             final long start = System.currentTimeMillis();
             for(final Row row : table) {

--- a/src/main/java/net/tlabs/tablesaw/parquet/TablesawParquetWriter.java
+++ b/src/main/java/net/tlabs/tablesaw/parquet/TablesawParquetWriter.java
@@ -22,6 +22,7 @@ package net.tlabs.tablesaw.parquet;
 
 import java.io.IOException;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.hadoop.ParquetFileWriter.Mode;
 import org.apache.parquet.hadoop.ParquetWriter;
@@ -51,13 +52,14 @@ public class TablesawParquetWriter implements DataWriter<TablesawParquetWriteOpt
 
     @Override
     public void write(final Table table, final TablesawParquetWriteOptions options) {
-//        try {
-//            org.apache.hadoop.fs.FileSystem fs = org.apache.hadoop.fs.FileSystem.getLocal(new Configuration());
-//            fs.setWriteChecksum(false);
-//        } catch (IOException e1) {
-//            // TODO Auto-generated catch block
-//            e1.printStackTrace();
-//        }
+        
+        try {
+            final FileSystem fs = FileSystem.getLocal(new Configuration());
+            fs.setWriteChecksum(options.isWriteChecksum());
+        } catch (IOException e) {
+            throw new RuntimeIOException(e);
+        }
+
         try (final ParquetWriter<Row> writer = new Builder(new Path(options.getOutputFile()), table)
                 .withCompressionCodec(CompressionCodecName.fromConf(options.getCompressionCodec().name()))
                 .withWriteMode(options.isOverwrite() ? Mode.OVERWRITE : Mode.CREATE).withValidation(false)

--- a/src/test/java/net/tlabs/tablesaw/parquet/TestParquetWriter.java
+++ b/src/test/java/net/tlabs/tablesaw/parquet/TestParquetWriter.java
@@ -60,6 +60,7 @@ class TestParquetWriter {
     private static final String APACHE_BYTE_ARRAY_DECIMAL = "byte_array_decimal.parquet";
     private static final String APACHE_DATAPAGEV2 = "datapage_v2.snappy.parquet";
     private static final String OUTPUT_FILE = "target/test/results/out.parquet";
+    private static final String OUTPUT_CRC_FILE = "target/test/results/.out.parquet.crc";
 
     private static final TablesawParquetWriter PARQUET_WRITER = new TablesawParquetWriter();
     private static final TablesawParquetReader PARQUET_READER = new TablesawParquetReader();
@@ -353,5 +354,25 @@ class TestParquetWriter {
         final Table dest = PARQUET_READER
             .read(TablesawParquetReadOptions.builder(OUTPUT_FILE).columnTypesToDetect(types).build());
         assertTableEquals(orig, dest, "All ColumnTypes reloaded");
+    }
+    
+    /**
+     * checksum file is removed when option is false
+     * checksum tests can be run in any order
+     */
+    @Test
+    void testWriteDefaultNoChecksum() {
+        final Table orig = Table.create(BooleanColumn.create("boolean", true, false));
+        PARQUET_WRITER.write(orig, TablesawParquetWriteOptions.builder(OUTPUT_FILE).build());
+        final File checksumFile = new File(OUTPUT_CRC_FILE);
+        assertFalse(checksumFile.exists(), "Default option for checksum is not false");
+    }
+
+    @Test
+    void testWriteOptionWithChecksum() {
+        final Table orig = Table.create(BooleanColumn.create("boolean", true, false));
+        PARQUET_WRITER.write(orig, TablesawParquetWriteOptions.builder(OUTPUT_FILE).withWriteChecksum(true).build());
+        final File checksumFile = new File(OUTPUT_CRC_FILE);
+        assertTrue(checksumFile.exists(), "Option with checksum does not generate checksum");
     }
 }


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Checksum files managed by writer option. Not generated by default.

Fixes #80 

## Testing

Yes
