### PR TITLE
Remove hadoop transitive deps

### DIFF
--- a/docs/hadoop_dependency.md
+++ b/docs/hadoop_dependency.md
@@ -10,9 +10,11 @@ Efforts to avoid depending on hadoop libraries can be followed on this [open iss
 
 ## Exclude transitive dependencies from hadoop libraries
 
-The hadoop libraries come with many transitive dependencies. If needed, some of them can probably be safely excluded from your project. See [issue #69](https://github.com/tlabs-data/tablesaw-parquet/issues/69) for a discussion on the topic.
+The hadoop libraries come with many transitive dependencies. Since `v0.13.0` those listed below are excluded from `tablesaw-parquet`.
 
-The following exclusions were successfully tested with `v0.10.0`:
+For previous versions, you will need to exclude them on your side as shown below:
+
+The following transitive dependencies exclusions were successfully tested with all versions since `v0.10.0`:
 
 ```xml
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -349,6 +349,34 @@
           <groupId>ch.qos.reload4j</groupId>
           <artifactId>reload4j</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.servlet.jsp</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.curator</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.zookeeper</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.kerby</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.protobuf</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <!-- Required to override resolved version -->


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Hadoop transitive dependencies listed in [the documentation](https://github.com/tlabs-data/tablesaw-parquet/blob/master/docs/hadoop_dependency.md#exclude-transitive-dependencies-from-hadoop-libraries) are now excluded

## Testing

Tests pass
