### PR TITLE
Reintroduce excluded parquet-testing file that now works fine

### DIFF
--- a/src/test/java/net/tlabs/tablesaw/parquet/TestAllParquetTestingFiles.java
+++ b/src/test/java/net/tlabs/tablesaw/parquet/TestAllParquetTestingFiles.java
@@ -69,12 +69,11 @@ class TestAllParquetTestingFiles {
         if (!filename.endsWith(".parquet")) return false;
         // brotli not supported
         if(filename.contains("brotli")) return false;
-        // parquet-mr reader fails on these ones
-        if(filename.equals("nation.dict-malformed.parquet")) return false;
-        if(filename.equals("fixed_length_byte_array.parquet")) return false;
-        if(filename.equals("repeated_primitive_no_list.parquet")) return false;
         // lz4 issue
         if(filename.equals("non_hadoop_lz4_compressed.parquet")) return false;
+        // parquet-java reader fails on these ones
+        if(filename.equals("nation.dict-malformed.parquet")) return false;
+        if(filename.equals("fixed_length_byte_array.parquet")) return false;
         // null logicalType
         if(filename.equals("unknown-logical-type.parquet")) return false;
         return true;


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Change only test case

## Testing

Add back an excluded test file that now works
