### PR TITLE
Add row group size writer option

### DIFF
--- a/src/main/java/net/tlabs/tablesaw/parquet/TablesawParquetWriteOptions.java
+++ b/src/main/java/net/tlabs/tablesaw/parquet/TablesawParquetWriteOptions.java
@@ -30,6 +30,7 @@ import java.util.Map.Entry;
 import org.apache.parquet.crypto.ColumnEncryptionProperties;
 import org.apache.parquet.crypto.FileEncryptionProperties;
 import org.apache.parquet.crypto.ParquetCipher;
+import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.metadata.ColumnPath;
 
 import tech.tablesaw.io.WriteOptions;
@@ -49,6 +50,7 @@ public class TablesawParquetWriteOptions extends WriteOptions {
     private final boolean overwrite;
     private final boolean writeChecksum;
     private final FileEncryptionProperties fileEncryptionProperties;
+    private final long rowGroupSize;
 
     public static Builder builder(final File file) {
         return new Builder(file.getAbsolutePath());
@@ -65,6 +67,7 @@ public class TablesawParquetWriteOptions extends WriteOptions {
         this.overwrite = builder.overwrite;
         this.writeChecksum = builder.writeChecksum;
         this.fileEncryptionProperties = builder.getEncryptionProperties();
+        this.rowGroupSize = builder.rowGroupSize;
     }
 
     public String getOutputFile() {
@@ -87,6 +90,10 @@ public class TablesawParquetWriteOptions extends WriteOptions {
         return fileEncryptionProperties;
     }
 
+    public long getRowGroupSize() {
+        return rowGroupSize;
+    }
+
     public static class Builder extends WriteOptions.Builder {
 
         private final String outputFile;
@@ -102,6 +109,7 @@ public class TablesawParquetWriteOptions extends WriteOptions {
         private boolean encryptedFooter = true;
         private byte[] footerKeyMetadata;
         private Map<String, byte[]> columnMetadataMap;
+        public long rowGroupSize = ParquetWriter.DEFAULT_BLOCK_SIZE;
 
         public Builder(final String outputFile) {
             super((Writer) null);
@@ -290,6 +298,17 @@ public class TablesawParquetWriteOptions extends WriteOptions {
         }
 
         /**
+         * Set the Parquet format row group size used by the constructed writer.
+         *
+         * @param rowGroupSize a long size in bytes
+         * @return this builder for method chaining.
+         */
+        public Builder withRowGroupSize(final long rowGroupSize) {
+          this.rowGroupSize = rowGroupSize;
+          return this;
+        }
+
+        /**
          * Build the {@link net.tlabs.tablesaw.parquet.TablesawParquetWriteOptions}
          * @return the options
          */
@@ -298,4 +317,5 @@ public class TablesawParquetWriteOptions extends WriteOptions {
         }
 
     }
+
 }

--- a/src/main/java/net/tlabs/tablesaw/parquet/TablesawParquetWriteOptions.java
+++ b/src/main/java/net/tlabs/tablesaw/parquet/TablesawParquetWriteOptions.java
@@ -109,7 +109,7 @@ public class TablesawParquetWriteOptions extends WriteOptions {
         private boolean encryptedFooter = true;
         private byte[] footerKeyMetadata;
         private Map<String, byte[]> columnMetadataMap;
-        public long rowGroupSize = ParquetWriter.DEFAULT_BLOCK_SIZE;
+        private long rowGroupSize = ParquetWriter.DEFAULT_BLOCK_SIZE;
 
         public Builder(final String outputFile) {
             super((Writer) null);

--- a/src/main/java/net/tlabs/tablesaw/parquet/TablesawParquetWriter.java
+++ b/src/main/java/net/tlabs/tablesaw/parquet/TablesawParquetWriter.java
@@ -65,6 +65,7 @@ public class TablesawParquetWriter implements DataWriter<TablesawParquetWriteOpt
                 .withWriteMode(options.isOverwrite() ? Mode.OVERWRITE : Mode.CREATE)
                 .withValidation(false)
                 .withEncryption(options.getFileEncryptionProperties())
+                .withRowGroupSize(options.getRowGroupSize())
                 .build()) {
             final long start = System.currentTimeMillis();
             for(final Row row : table) {

--- a/src/test/java/net/tlabs/tablesaw/parquet/TestParquetWriter.java
+++ b/src/test/java/net/tlabs/tablesaw/parquet/TestParquetWriter.java
@@ -599,4 +599,15 @@ class TestParquetWriter {
             .build();
         assertThrows(ParquetCryptoRuntimeException.class, () -> PARQUET_READER.read(options));
     }
+
+    @Test
+    void testRowGroupSizeOption() {
+        final Table orig = Table.create(BooleanColumn.create("boolean", true, false));
+        final TablesawParquetWriteOptions options = TablesawParquetWriteOptions.builder(OUTPUT_FILE)
+            .withRowGroupSize(2l * 1024 * 1024).build();
+        assertEquals(2l * 1024 * 1024, options.getRowGroupSize());
+        PARQUET_WRITER.write(orig, options);
+        final File checksumFile = new File(OUTPUT_FILE);
+        assertTrue(checksumFile.exists(), "Error writing smaller group size");
+    }
 }


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Added writer option to control parquet row group size

## Testing

Yes - also tested manually with larger file to check impact
