### PR TITLE
Update parquet java to 1.17

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,10 +59,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Set up JDK 17 # Required for sonar
+      - name: Set up JDK 21 # Required for sonar
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: 'temurin'
       - name: Cache SonarCloud packages
         uses: actions/cache@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
       - name: Windows download
         if: runner.os == 'Windows'
-        uses: carlosperate/download-file-action@v2
+        uses: carlosperate/download-file-action@3ec6fcef61e19eaaa0236a95fbaf333f2baf341e
         with:
           file-url: 'https://github.com/cdarlint/winutils/raw/master/hadoop-3.2.2/bin/winutils.exe'
           location: '${{github.workspace}}/hadoop/bin'

--- a/pom.xml
+++ b/pom.xml
@@ -44,10 +44,10 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <tablesaw.version>0.44.4</tablesaw.version>
-    <parquet.version>1.16.0</parquet.version>
+    <parquet.version>1.17.0</parquet.version>
     <hadoop.version>3.4.2</hadoop.version>
     <slf4j.version>2.0.17</slf4j.version>
-    <junit.version>5.13.4</junit.version>
+    <junit.version>5.14.2</junit.version>
     <!-- Sonar Cloud integration -->
     <sonar.projectKey>tlabs-data_tablesaw-parquet</sonar.projectKey>
     <sonar.organization>tlabs-data</sonar.organization>
@@ -91,7 +91,7 @@
 	    <plugin>
 	        <groupId>org.codehaus.mojo</groupId>
 	        <artifactId>versions-maven-plugin</artifactId>
-	        <version>2.19.1</version>
+	        <version>2.20.1</version>
 	        <configuration>
 				<ignoredVersions>(?i).*-(alpha|beta|m|rc)([-.]?\d+)?</ignoredVersions>
 	        </configuration>
@@ -110,7 +110,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>license-maven-plugin</artifactId>
-          <version>2.6.0</version>
+          <version>2.7.1</version>
         </plugin>
         <plugin>
           <groupId>com.googlecode.maven-download-plugin</groupId>
@@ -130,7 +130,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.11.3</version>
+          <version>3.12.0</version>
           <configuration>
             <source>11</source>
             <detectOfflineLinks>false</detectOfflineLinks>
@@ -151,7 +151,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
-          <version>3.3.1</version>
+          <version>3.4.0</version>
           <executions>
             <execution>
               <id>attach-sources</id>
@@ -164,7 +164,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.3.1</version>
           <configuration>
             <tagNameFormat>${tablesaw.version}-v@{project.version}</tagNameFormat>
             <autoVersionSubmodules>true</autoVersionSubmodules>
@@ -205,7 +205,7 @@
         <plugin>
           <groupId>org.sonarsource.scanner.maven</groupId>
           <artifactId>sonar-maven-plugin</artifactId>
-          <version>5.2.0.4988</version>
+          <version>5.5.0.6356</version>
         </plugin>
 	    <plugin>
     	  <groupId>org.apache.maven.plugins</groupId>
@@ -380,7 +380,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.20.0</version>
+      <version>2.20.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
@@ -408,7 +408,7 @@
 	<dependency>
 	    <groupId>at.yawk.lz4</groupId>
 	    <artifactId>lz4-java</artifactId>
-	    <version>1.10.1</version>
+	    <version>1.10.2</version>
 	</dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -430,7 +430,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>5.19.0</version>
+      <version>5.21.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/net/tlabs/tablesaw/parquet/TablesawParquetWriter.java
+++ b/src/main/java/net/tlabs/tablesaw/parquet/TablesawParquetWriter.java
@@ -83,6 +83,7 @@ public class TablesawParquetWriter implements DataWriter<TablesawParquetWriteOpt
 
         private final Table table;
 
+        @SuppressWarnings("deprecation")
         protected Builder(final Path path, final Table table) {
             super(path);
             this.table = table;


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Update parquet java to 1.17. Update other dependencies and plugins to latest versions.
Update CI workflow to use commit hash for external action

## Testing

No new test
