### PR TITLE
Register parquet MIME type in tablesaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ __maven:__
 
 ```xml
 <properties>
-    <tablesaw.version>0.42.0</tablesaw.version>
-    <tablesaw-parquet.version>0.10.0</tablesaw-parquet.version>
+    <tablesaw.version>0.44.4</tablesaw.version>
+    <tablesaw-parquet.version>0.14.1</tablesaw-parquet.version>
 </properties>
 
 <dependencies>
@@ -51,8 +51,8 @@ __gradle:__
 
 ```groovy
 ext {
-    tablesawVersion = "0.42.0"
-    tablesawParquetVersion = "0.10.0"
+    tablesawVersion = "0.44.4"
+    tablesawParquetVersion = "0.14.1"
 }
 
 dependencies {
@@ -118,7 +118,7 @@ Parquet files from http or ftp servers can be read using:
 Table table = new TablesawParquetReader().read(TablesawParquetReadOptions.builder(URL).build());
 ```
 
-You can also register the parquet reader and use the  __tablesaw__  read method. For this to work, the URL  __must__  end with  __".parquet"__  as there is currently no [parquet MIME type](https://github.com/apache/parquet-format/issues/381):
+You can also register the parquet reader and use the  __tablesaw__  read method. For this to work, the URL  __must__  end with  __".parquet"__  or the Content-Type  __must__  be the [official parquet MIME type](https://www.iana.org/assignments/media-types/application/vnd.apache.parquet) `application/vnd.apache.parquet`:
 
 ```java
 TablesawParquet.register();

--- a/src/main/java/net/tlabs/tablesaw/parquet/TablesawParquet.java
+++ b/src/main/java/net/tlabs/tablesaw/parquet/TablesawParquet.java
@@ -29,6 +29,7 @@ import tech.tablesaw.api.Table;
 public class TablesawParquet {
 
     private static final String PARQUET_EXTENSION = "parquet";
+    private static final String PARQUET_MIME_TYPE = "application/vnd.apache.parquet";
 
     private TablesawParquet() {
         super();
@@ -51,6 +52,7 @@ public class TablesawParquet {
         final TablesawParquetReader registeredInstance = new TablesawParquetReader();
         Table.defaultReaderRegistry.registerOptions(TablesawParquetReadOptions.class, registeredInstance);
         Table.defaultReaderRegistry.registerExtension(PARQUET_EXTENSION, registeredInstance);
+        Table.defaultReaderRegistry.registerMimeType(PARQUET_MIME_TYPE, registeredInstance);
     }
 
     /**

--- a/src/test/java/net/tlabs/tablesaw/parquet/TestParquetReadFromHTTP.java
+++ b/src/test/java/net/tlabs/tablesaw/parquet/TestParquetReadFromHTTP.java
@@ -46,7 +46,9 @@ class TestParquetReadFromHTTP {
 
     private static final int HTTP_PORT = 1080;
     private static final String HTTP_PATH = "/download/pandas_pyarrow.parquet";
+    private static final String HTTP_PATH_NOEXT = "/download/pandas_pyarrow";
     private static final String FILE_URL = "http://localhost:" + HTTP_PORT + HTTP_PATH;
+    private static final String FILE_URL_NOEXT = "http://localhost:" + HTTP_PORT + HTTP_PATH_NOEXT;
     private static ClientAndServer mockServer;
 
     @BeforeAll
@@ -67,7 +69,21 @@ class TestParquetReadFromHTTP {
                         header("Content-Type", "binary/octet-stream")
                     )
                     .withBody(binary(fileBytes))
-            );   
+            );
+            mockServer
+            .when(
+                request()
+                    .withPath(HTTP_PATH_NOEXT)
+            )
+            .respond(
+                response()
+                    .withStatusCode(HttpStatusCode.OK_200.code())
+                    .withHeaders(
+                        header("Content-Disposition", "inline"),
+                        header("Content-Type", "application/vnd.apache.parquet")
+                    )
+                    .withBody(binary(fileBytes))
+            );
         }
     }
  
@@ -94,6 +110,13 @@ class TestParquetReadFromHTTP {
     void testParquetFileFromHTTPUsingURI() throws URISyntaxException {
         final Table table = new TablesawParquetReader().read(
             TablesawParquetReadOptions.builder(new URI(FILE_URL)).build());
+        assertNotNull(table, "Table is null");
+    }
+
+    @Test
+    void testParquetFileFromHTTPUsingMimeType() {
+        TablesawParquet.registerReader();
+        final Table table = Table.read().url(FILE_URL_NOEXT);
         assertNotNull(table, "Table is null");
     }
 }


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Register parquet MIME type in tablesaw to facilitate remote file reading.

Closes #127 

## Testing

Unit test added
