### PR TITLE
Fix bug with Json parquet column 

### DIFF
--- a/src/main/java/net/tlabs/tablesaw/parquet/TablesawRecordConverter.java
+++ b/src/main/java/net/tlabs/tablesaw/parquet/TablesawRecordConverter.java
@@ -51,6 +51,7 @@ import org.apache.parquet.schema.LogicalTypeAnnotation.EnumLogicalTypeAnnotation
 import org.apache.parquet.schema.LogicalTypeAnnotation.GeographyLogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.GeometryLogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.IntervalLogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.JsonLogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.LogicalTypeAnnotationVisitor;
 import org.apache.parquet.schema.LogicalTypeAnnotation.StringLogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.TimeLogicalTypeAnnotation;
@@ -528,7 +529,13 @@ public class TablesawRecordConverter extends GroupConverter {
             @Override
             public Optional<Converter> visit(GeographyLogicalTypeAnnotation geographyLogicalType) {
                 return Optional.of(new GeospatialPrimitiveConverter(colIndex));
-            }           
+            }
+
+            @Override
+            public Optional<Converter> visit(JsonLogicalTypeAnnotation jsonLogicalType) {
+                return Optional.of(new StringPrimitiveConverter(colIndex));
+            }
+
         });
     }
 

--- a/src/test/java/net/tlabs/tablesaw/parquet/TestParquetReader.java
+++ b/src/test/java/net/tlabs/tablesaw/parquet/TestParquetReader.java
@@ -376,4 +376,15 @@ class TestParquetReader {
         assertEquals("[1,null,3]", table.column(0).getString(2), "Error decoding Json");
         assertTrue(table.column(0).isMissing(3));
     }
+
+    @Test
+    void testJsonColumnWithOption() {
+        final Table table = PARQUET_READER.read(TablesawParquetReadOptions.builder(PARQUET_TESTING_FOLDER + JSON_PARQUET)
+            .withUnnanotatedBinaryAs(UnnanotatedBinaryAs.HEXSTRING).build());
+        assertEquals(ColumnType.STRING, table.column(0).type(), "Json not encoded as string");      
+        assertEquals("{\"a\":1}", table.column(0).getString(0), "Error decoding Json");
+        assertEquals("{\"a\":1,\"b\":null}", table.column(0).getString(1), "Error decoding Json");
+        assertEquals("[1,null,3]", table.column(0).getString(2), "Error decoding Json");
+        assertTrue(table.column(0).isMissing(3));
+    }
 }


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Missing specific json converter makes parquet json column processed as unnannotated binary column. When the  `UnnanotatedBinaryAs.HEXSTRING` or `UnnanotatedBinaryAs.SKIP` options are used the column is read as an hex string instead of the json string.

## Testing

Added test case reproducing the issue
