### PR TITLE
Add support for BSON columns, skip VARIANT columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,8 @@ Annotated [parquet logical types](https://github.com/apache/parquet-format/blob/
 | TIMESTAMP | DateTimeColumn or InstantColumn | Timestamps normalized to UTC are converted to Instant, others as LocalDateTime |
 | INTERVAL | StringColumn | ISO String representation of the interval.  __Not tested__  |
 | JSON | StringColumn |  |
-| BSON |  StringColumn  |  As a Json String (Since v0.16)  |
+| BSON |  StringColumn  |  As a Json String (since v0.16)  |
+| VARIANT |  __Not supported__  |  Column is skipped  |
 | GEOMETRY |  StringColumn  |  Well-known text (WKT) representation of the geometry (since v0.14)  |
 | GEOGRAPHY |  StringColumn  |  Well-known text (WKT) representation of the geography (since v0.14)  |
 | Nested Types | StringColumn | Textual representation of the nested type, see *withManageGroupsAs* option |

--- a/README.md
+++ b/README.md
@@ -183,14 +183,12 @@ Annotated [parquet logical types](https://github.com/apache/parquet-format/blob/
 | TIMESTAMP | DateTimeColumn or InstantColumn | Timestamps normalized to UTC are converted to Instant, others as LocalDateTime |
 | INTERVAL | StringColumn | ISO String representation of the interval.  __Not tested__  |
 | JSON | StringColumn |  |
-| BSON |  __Not read__  |  __Not tested__  |
+| BSON |  StringColumn  |  As a Json String (Since v0.16)  |
 | GEOMETRY |  StringColumn  |  Well-known text (WKT) representation of the geometry (since v0.14)  |
 | GEOGRAPHY |  StringColumn  |  Well-known text (WKT) representation of the geography (since v0.14)  |
 | Nested Types | StringColumn | Textual representation of the nested type, see *withManageGroupsAs* option |
 
 Parquet also supports repeated fields (multiple values for the same field); we handle these as the Nested Types: by default a string representation of the repeated fields is stored in a StringColumn. The same *withManageGroupsAs* option is used to change this behavior.
-
-Due to the lack of parquet files for testing, some logical type conversion are currently not tested (INTERVAL, BSON).
 
 Keep in mind that all tablesaw columns storing time (TimeColumn, DateTimeColumn and InstantColumn) use MILLIS precision, if read from a parquet file with better time precision (MICROS or NANOS) the values will be truncated (in the current tablesaw implementation).
 

--- a/pom.xml
+++ b/pom.xml
@@ -411,6 +411,11 @@
 	    <version>1.11.1</version>
 	</dependency>
     <dependency>
+        <groupId>org.mongodb</groupId>
+        <artifactId>bson</artifactId>
+        <version>3.0.4</version>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>

--- a/src/main/java/net/tlabs/tablesaw/parquet/TablesawReadSupport.java
+++ b/src/main/java/net/tlabs/tablesaw/parquet/TablesawReadSupport.java
@@ -141,15 +141,6 @@ public class TablesawReadSupport extends ReadSupport<Row> {
                 if(type.getLogicalTypeAnnotation() == null) {
                     return this.options.getUnnanotatedBinaryAs() != UnnanotatedBinaryAs.SKIP;
                 }
-                // Filtering out BSON
-                return Optional.ofNullable(type.getLogicalTypeAnnotation())
-                    .flatMap(a -> a.accept(new LogicalTypeAnnotationVisitor<Boolean>() {
-                        @Override
-                        public Optional<Boolean> visit(final BsonLogicalTypeAnnotation bsonLogicalType) {
-                            return Optional.of(Boolean.FALSE);
-                        }
-                    }))
-                    .orElse(Boolean.TRUE);
                 //$CASES-OMITTED$
             default:
                 return true;
@@ -239,6 +230,11 @@ public class TablesawReadSupport extends ReadSupport<Row> {
 
             @Override
             public Optional<Column<?>> visit(final JsonLogicalTypeAnnotation jsonLogicalType) {
+                return Optional.of(StringColumn.create(fieldName));
+            }
+
+            @Override
+            public Optional<Column<?>> visit(final BsonLogicalTypeAnnotation bsonLogicalType) {
                 return Optional.of(StringColumn.create(fieldName));
             }
 

--- a/src/main/java/net/tlabs/tablesaw/parquet/TablesawReadSupport.java
+++ b/src/main/java/net/tlabs/tablesaw/parquet/TablesawReadSupport.java
@@ -44,6 +44,7 @@ import org.apache.parquet.schema.LogicalTypeAnnotation.LogicalTypeAnnotationVisi
 import org.apache.parquet.schema.LogicalTypeAnnotation.StringLogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.TimeLogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.TimestampLogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.VariantLogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.Type;
 import org.apache.parquet.schema.Type.Repetition;
@@ -120,10 +121,19 @@ public class TablesawReadSupport extends ReadSupport<Row> {
     }
     
     private boolean acceptFieldType(final Type type) {
-        if(type.isPrimitive() && !type.isRepetition(Repetition.REPEATED)) {
-            return acceptSimplePrimitives(type);
+        // Primitive types: accept based on options
+        if(type.isPrimitive()) {
+            return type.isRepetition(Repetition.REPEATED) ? acceptGroupsAndRepeatedFields() : acceptSimplePrimitives(type);
         }
-        return acceptGroupsAndRepeatedFields();
+        // Group type: reject VARIANT, accept other groups based on options
+        return Optional.ofNullable(type.getLogicalTypeAnnotation())
+            .flatMap(a -> a.accept(new LogicalTypeAnnotationVisitor<Boolean>() {
+                @Override
+                public Optional<Boolean> visit(final VariantLogicalTypeAnnotation variantLogicalType) {
+                    return Optional.of(Boolean.FALSE);
+                }
+            }))
+            .orElse(acceptGroupsAndRepeatedFields());
     }
 
     private boolean acceptGroupsAndRepeatedFields() {

--- a/src/main/java/net/tlabs/tablesaw/parquet/TablesawReadSupport.java
+++ b/src/main/java/net/tlabs/tablesaw/parquet/TablesawReadSupport.java
@@ -143,14 +143,12 @@ public class TablesawReadSupport extends ReadSupport<Row> {
     private boolean acceptSimplePrimitives(final Type type) {
         switch (type.asPrimitiveType().getPrimitiveTypeName()) {
             case FIXED_LEN_BYTE_ARRAY:
-                if(type.getLogicalTypeAnnotation() == null) {
-                    return this.options.getUnnanotatedBinaryAs() != UnnanotatedBinaryAs.SKIP;
-                }
-                return true;
+                // Fall through
             case BINARY:
                 if(type.getLogicalTypeAnnotation() == null) {
                     return this.options.getUnnanotatedBinaryAs() != UnnanotatedBinaryAs.SKIP;
                 }
+                return true;
                 //$CASES-OMITTED$
             default:
                 return true;
@@ -186,7 +184,7 @@ public class TablesawReadSupport extends ReadSupport<Row> {
             case SKIP:
                 throw new IllegalStateException("Skipped group " + name + " still in schema");
             case TEXT:
-                // CASCADE
+                // Fall through
             default:
                 return StringColumn.create(name);
         }

--- a/src/main/java/net/tlabs/tablesaw/parquet/TablesawRecordConverter.java
+++ b/src/main/java/net/tlabs/tablesaw/parquet/TablesawRecordConverter.java
@@ -46,6 +46,7 @@ import org.apache.parquet.io.api.GroupConverter;
 import org.apache.parquet.io.api.PrimitiveConverter;
 import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.BsonLogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.DecimalLogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.EnumLogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.GeographyLogicalTypeAnnotation;
@@ -62,6 +63,11 @@ import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 import org.apache.parquet.schema.Type.Repetition;
 import org.apache.parquet.schema.Type;
 import org.apache.parquet.tools.read.SimpleRecordConverter;
+import org.bson.BsonBinaryReader;
+import org.bson.BsonReader;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.DocumentCodec;
+import org.bson.json.JsonWriterSettings;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKBReader;
@@ -536,6 +542,21 @@ public class TablesawRecordConverter extends GroupConverter {
                 return Optional.of(new StringPrimitiveConverter(colIndex));
             }
 
+            @Override
+            public Optional<Converter> visit(BsonLogicalTypeAnnotation bsonLogicalType) {
+                return Optional.of(new PrimitiveConverter() {
+                    private final DocumentCodec documentReader = new DocumentCodec();
+                    private final DecoderContext context = DecoderContext.builder().build();
+                    private final JsonWriterSettings settings = new JsonWriterSettings();
+                    private final DocumentCodec codec = new DocumentCodec();
+                    @Override
+                    public void addBinary(final Binary value) {
+                        final BsonReader reader = new BsonBinaryReader(value.toByteBuffer());
+                        proxy.appendString(colIndex, documentReader.decode(reader, context).toJson(settings, codec));
+                    }
+                    
+                });
+            }  
         });
     }
 

--- a/src/test/java/net/tlabs/tablesaw/parquet/TestAllParquetTestingFiles.java
+++ b/src/test/java/net/tlabs/tablesaw/parquet/TestAllParquetTestingFiles.java
@@ -28,12 +28,16 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import net.tlabs.tablesaw.parquet.TablesawParquetReadOptions.Builder;
 import tech.tablesaw.api.ColumnType;
@@ -42,6 +46,7 @@ import tech.tablesaw.api.Table;
 class TestAllParquetTestingFiles {
 
     private static final String PARQUET_TESTING_FOLDER = "target/test/data/parquet-testing-master/data/";
+    private static final String PARQUET_VARIANT_FOLDER = "target/test/data/parquet-testing-master/shredded_variant/";
     private static final byte[] FOOTER_ENCRYPTION_KEY = new String("0123456789012345").getBytes();
     private static final byte[] COLUMN_ENCRYPTION_KEY1 = new String("1234567890123450").getBytes();
     private static final byte[] COLUMN_ENCRYPTION_KEY2 = new String("1234567890123451").getBytes();
@@ -229,5 +234,38 @@ class TestAllParquetTestingFiles {
         }
         final Table table = new TablesawParquetReader().read(optionBuilder.build());
         assertNotNull(table);
+    }
+
+    private static Stream<Arguments> listVarianrTestingFile() throws IOException {
+        final File caseFile = Path.of(PARQUET_VARIANT_FOLDER, "cases.json").toFile();
+        final List<Map<String, Object>> testCases = new ObjectMapper().readValue(caseFile,
+            new TypeReference<List<Map<String, Object>>>() {});
+        return testCases.stream()
+            .filter(TestAllParquetTestingFiles::filterVariantCase)
+            // Test only the 1st valid one as all are processed the same
+            .limit(1)
+            .map(c -> Path.of(PARQUET_VARIANT_FOLDER, c.get("parquet_file").toString()).toFile())
+            .map(Arguments::of);
+    }
+    
+    private static boolean filterVariantCase(final Map<String, Object> testCase) {
+        // filter out errors
+        if(testCase.containsKey("error_message")) return false;
+        // filter out invalid files
+        final Object filename = testCase.get("parquet_file");
+        // filter out missing case
+        if(filename == null) return false;
+        // filter out invalid files
+        if (filename.toString().contains("-INVALID")) return false;
+        return true;
+    }
+
+    @ParameterizedTest
+    @MethodSource("listVarianrTestingFile")
+    void testVariantTestingFile(final File parquetFile) {
+        final Builder optionBuilder = TablesawParquetReadOptions.builder(parquetFile);
+        final Table table = new TablesawParquetReader().read(optionBuilder.build());
+        assertNotNull(table);
+        assertEquals(1, table.columnCount(), "Variant column should be skipped");
     }
 }

--- a/src/test/java/net/tlabs/tablesaw/parquet/TestDefaultReadPyArrow.java
+++ b/src/test/java/net/tlabs/tablesaw/parquet/TestDefaultReadPyArrow.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.time.LocalDateTime;
+import java.time.Month;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.provider.Arguments;
@@ -74,8 +75,8 @@ class TestDefaultReadPyArrow extends AbstractTableParameterizedTest {
             Arguments.of(9, 1, 1.0d, "double"),
             Arguments.of(10, 0, 0.0d, "double"),
             Arguments.of(10, 1, null, "double"),
-            Arguments.of(11, 0, LocalDateTime.of(2021, 4, 23, 0, 0), "LocalDateTime"),
-            Arguments.of(11, 1, LocalDateTime.of(2021, 4, 23, 0, 0, 1), "LocalDateTime"),
+            Arguments.of(11, 0, LocalDateTime.of(2021, Month.APRIL, 23, 0, 0), "LocalDateTime"),
+            Arguments.of(11, 1, LocalDateTime.of(2021, Month.APRIL, 23, 0, 0, 1), "LocalDateTime"),
             Arguments.of(12, 0, "string1", "String"),
             Arguments.of(12, 1, "string2", "String"));
     }

--- a/src/test/java/net/tlabs/tablesaw/parquet/TestFastparquetColumnTypeOptions.java
+++ b/src/test/java/net/tlabs/tablesaw/parquet/TestFastparquetColumnTypeOptions.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.time.LocalDateTime;
+import java.time.Month;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.provider.Arguments;
@@ -74,8 +75,8 @@ class TestFastparquetColumnTypeOptions extends AbstractTableParameterizedTest {
             Arguments.of(9, 1, 1.0d, "double"),
             Arguments.of(10, 0, 0.0d, "double"),
             Arguments.of(10, 1, null, "double"),
-            Arguments.of(11, 0, LocalDateTime.of(2021, 4, 23, 0, 0), "LocalDateTime"),
-            Arguments.of(11, 1, LocalDateTime.of(2021, 4, 23, 0, 0, 1), "LocalDateTime"),
+            Arguments.of(11, 0, LocalDateTime.of(2021, Month.APRIL, 23, 0, 0), "LocalDateTime"),
+            Arguments.of(11, 1, LocalDateTime.of(2021, Month.APRIL, 23, 0, 0, 1), "LocalDateTime"),
             Arguments.of(12, 0, "string1", "Test"),
             Arguments.of(12, 1, "string2", "Text"));
     }

--- a/src/test/java/net/tlabs/tablesaw/parquet/TestMinimizedReadPyArrow.java
+++ b/src/test/java/net/tlabs/tablesaw/parquet/TestMinimizedReadPyArrow.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.time.LocalDateTime;
+import java.time.Month;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.provider.Arguments;
@@ -74,8 +75,8 @@ class TestMinimizedReadPyArrow extends AbstractTableParameterizedTest {
             Arguments.of(9, 1, 1.0f, "float"),
             Arguments.of(10, 0, 0.0d, "double"),
             Arguments.of(10, 1, null, "double"),
-            Arguments.of(11, 0, LocalDateTime.of(2021, 4, 23, 0, 0), "LocalDateTime"),
-            Arguments.of(11, 1, LocalDateTime.of(2021, 4, 23, 0, 0, 1), "LocalDateTime"),
+            Arguments.of(11, 0, LocalDateTime.of(2021, Month.APRIL, 23, 0, 0), "LocalDateTime"),
+            Arguments.of(11, 1, LocalDateTime.of(2021, Month.APRIL, 23, 0, 0, 1), "LocalDateTime"),
             Arguments.of(12, 0, "string1", "String"),
             Arguments.of(12, 1, "string2", "String"));
     }

--- a/src/test/java/net/tlabs/tablesaw/parquet/TestParquetReader.java
+++ b/src/test/java/net/tlabs/tablesaw/parquet/TestParquetReader.java
@@ -32,6 +32,8 @@ import java.nio.charset.StandardCharsets;
 import net.tlabs.tablesaw.parquet.TablesawParquetReadOptions.Builder;
 import net.tlabs.tablesaw.parquet.TablesawParquetReadOptions.ManageGroupsAs;
 import net.tlabs.tablesaw.parquet.TablesawParquetReadOptions.UnnanotatedBinaryAs;
+
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 import tech.tablesaw.api.ColumnType;
 import tech.tablesaw.api.Table;
@@ -56,6 +58,7 @@ class TestParquetReader {
     private static final String GUID_PARQUET = "target/test-classes/guid.parquet";
     private static final String UUID_PARQUET = "target/test-classes/uuid.parquet";
     private static final String JSON_PARQUET = "json.parquet";
+    private static final String BSON_PARQUET = "bson.parquet";
 
     private static final TablesawParquetReader PARQUET_READER = new TablesawParquetReader();
 
@@ -386,5 +389,15 @@ class TestParquetReader {
         assertEquals("{\"a\":1,\"b\":null}", table.column(0).getString(1), "Error decoding Json");
         assertEquals("[1,null,3]", table.column(0).getString(2), "Error decoding Json");
         assertTrue(table.column(0).isMissing(3));
+    }
+
+    @Test
+    void testBsonColumn() {
+        final Table table = PARQUET_READER.read(TablesawParquetReadOptions.builder(PARQUET_TESTING_FOLDER + BSON_PARQUET).build());
+        assertEquals(ColumnType.STRING, table.column(0).type(), "Bson not encoded as string");
+        // Json formatting is different than in original file once decoded
+        assertEquals("{\"a\":1}", StringUtils.deleteWhitespace(table.column(0).getString(0)), "Error decoding Bson");
+        assertEquals("{\"a\":1,\"b\":null}", StringUtils.deleteWhitespace(table.column(0).getString(1)), "Error decoding Bson");
+        assertTrue(table.column(0).isMissing(2));
     }
 }


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

- BSON parquet columns are now read as a Json String
- VARIANT parquet columns are now skipped as they are not read properly

## Testing

Yes
