### PR TITLE
Writer option to set the parquet LogicalType of tablesaw StringColumn

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Annotated [parquet logical types](https://github.com/apache/parquet-format/blob/
 | DATE | DateColumn |  |
 | TIME | TimeColumn |  |
 | TIMESTAMP | DateTimeColumn or InstantColumn | Timestamps normalized to UTC are converted to Instant, others as LocalDateTime |
-| INTERVAL | StringColumn | ISO String representation of the interval.  __Not tested__  |
+| INTERVAL | StringColumn | ISO 8601 String representation of the interval.  |
 | JSON | StringColumn |  |
 | BSON |  StringColumn  |  As a Json String (since v0.16)  |
 | VARIANT |  __Not supported__  |  Column is skipped  |
@@ -216,15 +216,17 @@ Note that the `ColumnType.SKIP` column type can be used with these options to fi
 | LongColumn | INT64 |  |
 | FloatColumn | FLOAT |  |
 | DoubleColumn | DOUBLE |  |
-| StringColumn | BINARY (STRING) |  |
+| StringColumn | BINARY (STRING) |  Can be configured by the *withLogicalTypes* option (since v0.16, see below)  |
 | TimeColumn | INT32 (TIME: MILLIS, not UTC) | *Changed in v0.11.0, was INT64 (TIME: NANOS, not UTC) before* |
 | DateColumn | INT32 (DATE) |  |
 | DateTimeColumn | INT64 (TIMESTAMP: MILLIS, not UTC) |  |
 | InstantColumn | INT64 (TIMESTAMP: MILLIS, UTC) |  |
 
-Note that a tablesaw Table written to parquet and read back with default conversion will have the following changes:
+Note that a tablesaw Table written to parquet and read back with default options will have Floats changed to Doubles and Shorts to Integers, as the *minimizeColumnSizes* reader option is false by default.
 
-* If the *minimizeColumnSizes* option is not set (which is the default), Floats will be changed to Doubles and Shorts to Integers.
+Since v0.16, the `TablesawParquetWriteOptions.withLogicalTypes` method allows to specify a different Logical Type for StringColum. Available types are UUID, INTERVAL, JSON, and BSON. The column values must be valid representations of these types and no validation is done before converting data. If the option is used with another tablesaw column type than StringColumn, an `IllegalArgumentException` is raised when writing.
+
+Note that parquet INTERVAL only supports Month and Days for the Period part, and the Duration part does not support Days and has MILLI precision only.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Note that a tablesaw Table written to parquet and read back with default options
 
 Since v0.16, the `TablesawParquetWriteOptions.withLogicalTypes` method allows to specify a different Logical Type for StringColum. Available types are UUID, INTERVAL, JSON, and BSON. The column values must be valid representations of these types and no validation is done before converting data. If the option is used with another tablesaw column type than StringColumn, an `IllegalArgumentException` is raised when writing.
 
-Note that parquet INTERVAL only supports Month and Days for the Period part, and the Duration part does not support Days and has MILLI precision only.
+Note that parquet INTERVAL only supports Month and Days for the Period part, and the Duration part does not support Days and has MILLI precision only. Leading plus or minus signs are not supported, plus or minus signs on individual sections are supported.
 
 ## Features
 

--- a/src/main/java/net/tlabs/tablesaw/parquet/TablesawParquetWriteOptions.java
+++ b/src/main/java/net/tlabs/tablesaw/parquet/TablesawParquetWriteOptions.java
@@ -50,7 +50,8 @@ public class TablesawParquetWriteOptions extends WriteOptions {
     public enum LogicalType {
         UUID(LogicalTypeAnnotation.uuidType()),
         JSON(LogicalTypeAnnotation.jsonType()),
-        BSON(LogicalTypeAnnotation.bsonType());
+        BSON(LogicalTypeAnnotation.bsonType()),
+        INTERVAL(LogicalTypeAnnotation.intervalType());
         
         final LogicalTypeAnnotation logicalType;
         

--- a/src/main/java/net/tlabs/tablesaw/parquet/TablesawParquetWriteOptions.java
+++ b/src/main/java/net/tlabs/tablesaw/parquet/TablesawParquetWriteOptions.java
@@ -49,7 +49,8 @@ public class TablesawParquetWriteOptions extends WriteOptions {
     
     public enum LogicalType {
         UUID(LogicalTypeAnnotation.uuidType()),
-        JSON(LogicalTypeAnnotation.jsonType());
+        JSON(LogicalTypeAnnotation.jsonType()),
+        BSON(LogicalTypeAnnotation.bsonType());
         
         final LogicalTypeAnnotation logicalType;
         

--- a/src/main/java/net/tlabs/tablesaw/parquet/TablesawParquetWriteOptions.java
+++ b/src/main/java/net/tlabs/tablesaw/parquet/TablesawParquetWriteOptions.java
@@ -48,7 +48,8 @@ public class TablesawParquetWriteOptions extends WriteOptions {
     }
     
     public enum LogicalType {
-        UUID(LogicalTypeAnnotation.uuidType());
+        UUID(LogicalTypeAnnotation.uuidType()),
+        JSON(LogicalTypeAnnotation.jsonType());
         
         final LogicalTypeAnnotation logicalType;
         

--- a/src/main/java/net/tlabs/tablesaw/parquet/TablesawParquetWriteOptions.java
+++ b/src/main/java/net/tlabs/tablesaw/parquet/TablesawParquetWriteOptions.java
@@ -53,14 +53,14 @@ public class TablesawParquetWriteOptions extends WriteOptions {
         BSON(LogicalTypeAnnotation.bsonType()),
         INTERVAL(LogicalTypeAnnotation.intervalType());
         
-        final LogicalTypeAnnotation logicalType;
+        final LogicalTypeAnnotation logicalTypeAnnotation;
         
-        LogicalType(final LogicalTypeAnnotation logicalType) {
-            this.logicalType = logicalType;
+        LogicalType(final LogicalTypeAnnotation logicalTypeAnnotation) {
+            this.logicalTypeAnnotation = logicalTypeAnnotation;
         }
         
         LogicalTypeAnnotation getLogicalTypeAnnotation() {
-            return this.logicalType;
+            return this.logicalTypeAnnotation;
         }
     }
 
@@ -344,7 +344,7 @@ public class TablesawParquetWriteOptions extends WriteOptions {
          */
         public Builder withLogicalTypes(final Map<String, LogicalType> logicalTypes) {
             this.logicalTypes.putAll(logicalTypes.entrySet().stream().collect(
-                Collectors.toMap(e -> e.getKey(), e -> e.getValue().getLogicalTypeAnnotation())));
+                Collectors.toMap(Entry::getKey, e -> e.getValue().getLogicalTypeAnnotation())));
             return this;
         }
 

--- a/src/main/java/net/tlabs/tablesaw/parquet/TablesawParquetWriteOptions.java
+++ b/src/main/java/net/tlabs/tablesaw/parquet/TablesawParquetWriteOptions.java
@@ -23,16 +23,18 @@ package net.tlabs.tablesaw.parquet;
 import java.io.File;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.stream.Collectors;
 
 import org.apache.parquet.crypto.ColumnEncryptionProperties;
 import org.apache.parquet.crypto.FileEncryptionProperties;
 import org.apache.parquet.crypto.ParquetCipher;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.metadata.ColumnPath;
-
+import org.apache.parquet.schema.LogicalTypeAnnotation;
 import tech.tablesaw.io.WriteOptions;
 
 /**
@@ -44,6 +46,20 @@ public class TablesawParquetWriteOptions extends WriteOptions {
     public enum CompressionCodec {
         UNCOMPRESSED, SNAPPY, GZIP, ZSTD, LZ4
     }
+    
+    public enum LogicalType {
+        UUID(LogicalTypeAnnotation.uuidType());
+        
+        final LogicalTypeAnnotation logicalType;
+        
+        LogicalType(final LogicalTypeAnnotation logicalType) {
+            this.logicalType = logicalType;
+        }
+        
+        LogicalTypeAnnotation getLogicalTypeAnnotation() {
+            return this.logicalType;
+        }
+    }
 
     private final String outputFile;
     private final CompressionCodec compressionCodec;
@@ -51,6 +67,7 @@ public class TablesawParquetWriteOptions extends WriteOptions {
     private final boolean writeChecksum;
     private final FileEncryptionProperties fileEncryptionProperties;
     private final long rowGroupSize;
+    private final Map<String, LogicalTypeAnnotation> logicalTypes;
 
     public static Builder builder(final File file) {
         return new Builder(file.getAbsolutePath());
@@ -68,6 +85,7 @@ public class TablesawParquetWriteOptions extends WriteOptions {
         this.writeChecksum = builder.writeChecksum;
         this.fileEncryptionProperties = builder.getEncryptionProperties();
         this.rowGroupSize = builder.rowGroupSize;
+        this.logicalTypes = Collections.unmodifiableMap(builder.logicalTypes);
     }
 
     public String getOutputFile() {
@@ -94,6 +112,10 @@ public class TablesawParquetWriteOptions extends WriteOptions {
         return rowGroupSize;
     }
 
+    public Map<String, LogicalTypeAnnotation> getLogicalTypes() {
+        return logicalTypes;
+    }
+
     public static class Builder extends WriteOptions.Builder {
 
         private final String outputFile;
@@ -110,6 +132,7 @@ public class TablesawParquetWriteOptions extends WriteOptions {
         private byte[] footerKeyMetadata;
         private Map<String, byte[]> columnMetadataMap;
         private long rowGroupSize = ParquetWriter.DEFAULT_BLOCK_SIZE;
+        private Map<String, LogicalTypeAnnotation> logicalTypes = new HashMap<>();
 
         public Builder(final String outputFile) {
             super((Writer) null);
@@ -306,6 +329,20 @@ public class TablesawParquetWriteOptions extends WriteOptions {
         public Builder withRowGroupSize(final long rowGroupSize) {
           this.rowGroupSize = rowGroupSize;
           return this;
+        }
+        
+        /**
+         * Set the logical type to use for some columns when writing parquet file.
+         * Intended to write parquet files using native type for columns liks UUID or geometry
+         * that are read as StringColumn in tablesaw.
+         * Accumulative method, can be called multiple times. Type accumulate in the internal map. 
+         * @param logicalTypes map of column names to {{@link #logicalTypes}
+         * @return this builder for method chaining.
+         */
+        public Builder withLogicalTypes(final Map<String, LogicalType> logicalTypes) {
+            this.logicalTypes.putAll(logicalTypes.entrySet().stream().collect(
+                Collectors.toMap(e -> e.getKey(), e -> e.getValue().getLogicalTypeAnnotation())));
+            return this;
         }
 
         /**

--- a/src/main/java/net/tlabs/tablesaw/parquet/TablesawParquetWriter.java
+++ b/src/main/java/net/tlabs/tablesaw/parquet/TablesawParquetWriter.java
@@ -94,7 +94,7 @@ public class TablesawParquetWriter implements DataWriter<TablesawParquetWriteOpt
             this.table = table;
         }
 
-        protected Builder withLogicalTypes(Map<String, LogicalTypeAnnotation> logicalTypes) {
+        protected Builder withLogicalTypes(final Map<String, LogicalTypeAnnotation> logicalTypes) {
             this.logicalTypes = logicalTypes;
             return self();
         }

--- a/src/main/java/net/tlabs/tablesaw/parquet/TablesawParquetWriter.java
+++ b/src/main/java/net/tlabs/tablesaw/parquet/TablesawParquetWriter.java
@@ -21,6 +21,8 @@ package net.tlabs.tablesaw.parquet;
  */
 
 import java.io.IOException;
+import java.util.Map;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -28,6 +30,7 @@ import org.apache.parquet.hadoop.ParquetFileWriter.Mode;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.api.WriteSupport;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import tech.tablesaw.api.Row;
@@ -66,6 +69,7 @@ public class TablesawParquetWriter implements DataWriter<TablesawParquetWriteOpt
                 .withValidation(false)
                 .withEncryption(options.getFileEncryptionProperties())
                 .withRowGroupSize(options.getRowGroupSize())
+                .withLogicalTypes(options.getLogicalTypes())
                 .build()) {
             final long start = System.currentTimeMillis();
             for(final Row row : table) {
@@ -82,11 +86,17 @@ public class TablesawParquetWriter implements DataWriter<TablesawParquetWriteOpt
     protected static class Builder extends ParquetWriter.Builder<Row, Builder> {
 
         private final Table table;
-
+        private Map<String, LogicalTypeAnnotation> logicalTypes;
+        
         @SuppressWarnings("deprecation")
         protected Builder(final Path path, final Table table) {
             super(path);
             this.table = table;
+        }
+
+        protected Builder withLogicalTypes(Map<String, LogicalTypeAnnotation> logicalTypes) {
+            this.logicalTypes = logicalTypes;
+            return self();
         }
 
         @Override
@@ -97,7 +107,7 @@ public class TablesawParquetWriter implements DataWriter<TablesawParquetWriteOpt
         @SuppressWarnings("deprecation")
         @Override
         protected WriteSupport<Row> getWriteSupport(final Configuration conf) {
-            return new TablesawWriteSupport(this.table);
+            return new TablesawWriteSupport(this.table, this.logicalTypes);
         }
     }
 }

--- a/src/main/java/net/tlabs/tablesaw/parquet/TablesawRecordConverter.java
+++ b/src/main/java/net/tlabs/tablesaw/parquet/TablesawRecordConverter.java
@@ -545,14 +545,13 @@ public class TablesawRecordConverter extends GroupConverter {
             @Override
             public Optional<Converter> visit(BsonLogicalTypeAnnotation bsonLogicalType) {
                 return Optional.of(new PrimitiveConverter() {
-                    private final DocumentCodec documentReader = new DocumentCodec();
                     private final DecoderContext context = DecoderContext.builder().build();
                     private final JsonWriterSettings settings = JsonWriterSettings.builder().build();
                     private final DocumentCodec codec = new DocumentCodec();
                     @Override
                     public void addBinary(final Binary value) {
                         final BsonReader reader = new BsonBinaryReader(value.toByteBuffer());
-                        proxy.appendString(colIndex, documentReader.decode(reader, context).toJson(settings, codec));
+                        proxy.appendString(colIndex, codec.decode(reader, context).toJson(settings, codec));
                     }
                     
                 });

--- a/src/main/java/net/tlabs/tablesaw/parquet/TablesawRecordConverter.java
+++ b/src/main/java/net/tlabs/tablesaw/parquet/TablesawRecordConverter.java
@@ -83,6 +83,8 @@ public class TablesawRecordConverter extends GroupConverter {
     private static final String BINARY_INSTANT_LENGTH_MESSAGE = "Must be 12 bytes";
     private static final int BINARY_INTERVAL_LENGTH_VALUE = 12;
     private static final String BINARY_INTERVAL_LENGTH_MESSAGE = "Must be 12 bytes";
+    private static final String INTERVAL_PERIOD_DESIGNATOR = "P";
+    private static final String INTERVAL_ZERO_STRING_REPRESENTATION = "P0D";
     private static final int BINARY_UUID_LENGTH_VALUE = 16;
     private static final String BINARY_UUID_LENGTH_MESSAGE = "Must be 16 bytes";
 
@@ -512,13 +514,13 @@ public class TablesawRecordConverter extends GroupConverter {
                         final StringBuilder builder = new StringBuilder();
                         // Handle case where all values are 0, as P is not a valid period
                         if(months == 0 && days == 0 && millis == 0) {
-                            builder.append("P0D");
+                            builder.append(INTERVAL_ZERO_STRING_REPRESENTATION);
                         } else {
                             if (months != 0 || days != 0) {
                                 builder.append(Period.ofMonths(months).plusDays(days).toString());
                             } else {
                                 // No Duration, requires the P header
-                                builder.append("P");
+                                builder.append(INTERVAL_PERIOD_DESIGNATOR);
                             }
                             // Skip time block if 0
                             if(millis != 0) {

--- a/src/main/java/net/tlabs/tablesaw/parquet/TablesawRecordConverter.java
+++ b/src/main/java/net/tlabs/tablesaw/parquet/TablesawRecordConverter.java
@@ -506,9 +506,26 @@ public class TablesawRecordConverter extends GroupConverter {
                             BINARY_INTERVAL_LENGTH_MESSAGE);
                         final ByteBuffer buf = value.toByteBuffer();
                         buf.order(ByteOrder.LITTLE_ENDIAN);
-                        proxy.appendString(colIndex,
-                            Period.ofMonths(buf.getInt()).plusDays(buf.getInt()).toString()
-                                + Duration.ofMillis(buf.getInt()).toString().substring(1));
+                        final int months = buf.getInt();
+                        final int days = buf.getInt();
+                        final int millis = buf.getInt();
+                        final StringBuilder builder = new StringBuilder();
+                        // Handle case where all values are 0, as P is not a valid period
+                        if(months == 0 && days == 0 && millis == 0) {
+                            builder.append("P0D");
+                        } else {
+                            if (months != 0 || days != 0) {
+                                builder.append(Period.ofMonths(months).plusDays(days).toString());
+                            } else {
+                                // No Duration, requires the P header
+                                builder.append("P");
+                            }
+                            // Skip time block if 0
+                            if(millis != 0) {
+                                builder.append(Duration.ofMillis(millis).toString().substring(1));
+                            }
+                        }
+                        proxy.appendString(colIndex, builder.toString());
                     }
                 });
             }

--- a/src/main/java/net/tlabs/tablesaw/parquet/TablesawWriteSupport.java
+++ b/src/main/java/net/tlabs/tablesaw/parquet/TablesawWriteSupport.java
@@ -98,7 +98,8 @@ public class TablesawWriteSupport extends WriteSupport<Row> {
         UUID(ColumnType.STRING) {
             private final ByteBuffer buffer = ByteBuffer.allocateDirect(16);
             @Override
-            void recordValue(RecordConsumer recordConsumer, TableProxy tableProxy, int colIndex, int rowNumber) {
+            void recordValue(final RecordConsumer recordConsumer, final TableProxy tableProxy,
+                    final int colIndex, final int rowNumber) {
                 final UUID uuid = java.util.UUID.fromString(tableProxy.getString(colIndex, rowNumber));
                 buffer
                     .clear()
@@ -202,8 +203,10 @@ public class TablesawWriteSupport extends WriteSupport<Row> {
         RECORDER_MAPPING.put(ColumnType.STRING, FieldRecorder.STRING);
         LOGICALTYPE_MAPPING = new HashMap<>();
         LOGICALTYPE_MAPPING.put(LogicalTypeAnnotation.uuidType(), PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY);
+        LOGICALTYPE_MAPPING.put(LogicalTypeAnnotation.jsonType(), PrimitiveTypeName.BINARY);
         LOGICALTYPE_RECORDER_MAPPING = new HashMap<>();
         LOGICALTYPE_RECORDER_MAPPING.put(LogicalTypeAnnotation.uuidType(), FieldRecorder.UUID);
+        LOGICALTYPE_RECORDER_MAPPING.put(LogicalTypeAnnotation.jsonType(), FieldRecorder.STRING);
     }
 
     public TablesawWriteSupport(final Table table) {
@@ -231,7 +234,7 @@ public class TablesawWriteSupport extends WriteSupport<Row> {
         final ColumnType type = column.type();
         final String name = column.name();
         return Types
-            .optional(LOGICALTYPE_MAPPING.getOrDefault(typeMap.getOrDefault(column.name(), null), PRIMITIVE_MAPPING.get(type)))
+            .optional(LOGICALTYPE_MAPPING.getOrDefault(typeMap.get(name), PRIMITIVE_MAPPING.get(type)))
             .as(typeMap.getOrDefault(name, ANNOTATION_MAPPING.get(type)))
             .named(name);
     }
@@ -245,7 +248,7 @@ public class TablesawWriteSupport extends WriteSupport<Row> {
     
     private FieldRecorder createRecorder(final Column<?> column) {
         final FieldRecorder recorder = LOGICALTYPE_RECORDER_MAPPING
-            .getOrDefault(typeMap.getOrDefault(column.name(), null), RECORDER_MAPPING.get(column.type()));
+            .getOrDefault(typeMap.get(column.name()), RECORDER_MAPPING.get(column.type()));
         recorder.validate(column.type());
         return recorder;
     }

--- a/src/main/java/net/tlabs/tablesaw/parquet/TablesawWriteSupport.java
+++ b/src/main/java/net/tlabs/tablesaw/parquet/TablesawWriteSupport.java
@@ -167,12 +167,12 @@ public class TablesawWriteSupport extends WriteSupport<Row> {
             @Override
             void recordValue(final RecordConsumer recordConsumer, final TableProxy tableProxy, 
                     final int colIndex, final int rowNumber) {
-                final String[] values = tableProxy.getString(colIndex, rowNumber).split("T");
+                final String[] values = tableProxy.getString(colIndex, rowNumber).split(INTERVAL_TIME_DESIGNATOR);
                 // Handle no period only duration (PTxxx) case, as "P" is not a valid Period
                 final Period period = values[0].length() > 1 ? Period.parse(values[0]) : emptyPeriod;
                 // Handle no duration only period (Pxxx) case, as T is omitted
                 final Duration duration = values.length > 1 ?
-                    Duration.parse(new StringBuilder("PT").append(values[1]).toString()) : emptyDuration;
+                    Duration.parse(new StringBuilder(INTERVAL_TIME_ONLY_DESIGNATOR).append(values[1]).toString()) : emptyDuration;
                 buffer
                     .clear()
                     .putInt(period.getMonths())
@@ -183,6 +183,8 @@ public class TablesawWriteSupport extends WriteSupport<Row> {
             }
         };
 
+        private static final String INTERVAL_TIME_ONLY_DESIGNATOR = "PT";
+        private static final String INTERVAL_TIME_DESIGNATOR = "T";
         final ColumnType columnType;
         
         private FieldRecorder(final ColumnType columnType) {

--- a/src/main/java/net/tlabs/tablesaw/parquet/TablesawWriteSupport.java
+++ b/src/main/java/net/tlabs/tablesaw/parquet/TablesawWriteSupport.java
@@ -21,6 +21,9 @@ package net.tlabs.tablesaw.parquet;
  */
 
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.time.Duration;
+import java.time.Period;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -34,9 +37,11 @@ import org.apache.parquet.io.api.RecordConsumer;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.TimeUnit;
 import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 import org.apache.parquet.schema.Type;
 import org.apache.parquet.schema.Types;
+import org.apache.parquet.schema.Types.PrimitiveBuilder;
 import org.bson.BsonBinaryWriter;
 import org.bson.Document;
 import org.bson.codecs.DocumentCodec;
@@ -154,6 +159,28 @@ public class TablesawWriteSupport extends WriteSupport<Row> {
                     final int colIndex, final int rowNumber) {
                 recordConsumer.addLong(tableProxy.getInstantAsEpochMilli(colIndex, rowNumber));
             }
+        },
+        INTERVAL(ColumnType.STRING) {
+            private final ByteBuffer buffer = ByteBuffer.allocateDirect(12).order(ByteOrder.LITTLE_ENDIAN);
+            private final Period emptyPeriod = Period.of(0, 0, 0);
+            private final Duration emptyDuration = Duration.ofMillis(0);
+            @Override
+            void recordValue(final RecordConsumer recordConsumer, final TableProxy tableProxy, 
+                    final int colIndex, final int rowNumber) {
+                final String[] values = tableProxy.getString(colIndex, rowNumber).split("T");
+                // Handle no period only duration (PTxxx) case, as "P" is not a valid Period
+                final Period period = values[0].length() > 1 ? Period.parse(values[0]) : emptyPeriod;
+                // Handle no duration only period (Pxxx) case, as T is omitted
+                final Duration duration = values.length > 1 ?
+                    Duration.parse(new StringBuilder("PT").append(values[1]).toString()) : emptyDuration;
+                buffer
+                    .clear()
+                    .putInt(period.getMonths())
+                    .putInt(period.getDays())
+                    .putInt((int)duration.toMillis())
+                    .rewind();
+                recordConsumer.addBinary(Binary.fromReusedByteBuffer(buffer));
+            }
         };
 
         final ColumnType columnType;
@@ -180,6 +207,7 @@ public class TablesawWriteSupport extends WriteSupport<Row> {
     private static final Map<ColumnType, FieldRecorder> RECORDER_MAPPING;
     private static final Map<LogicalTypeAnnotation, FieldRecorder> LOGICALTYPE_RECORDER_MAPPING;
     private static final Map<LogicalTypeAnnotation, PrimitiveTypeName> LOGICALTYPE_MAPPING;
+    private static final Map<LogicalTypeAnnotation, Integer> LOGICALTYPE_FIELD_LENGTH;
     private final TableProxy proxy;
     private final MessageType schema;
     private final int nbfields;
@@ -223,10 +251,15 @@ public class TablesawWriteSupport extends WriteSupport<Row> {
         LOGICALTYPE_MAPPING.put(LogicalTypeAnnotation.uuidType(), PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY);
         LOGICALTYPE_MAPPING.put(LogicalTypeAnnotation.jsonType(), PrimitiveTypeName.BINARY);
         LOGICALTYPE_MAPPING.put(LogicalTypeAnnotation.bsonType(), PrimitiveTypeName.BINARY);
+        LOGICALTYPE_MAPPING.put(LogicalTypeAnnotation.intervalType(), PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY);
+        LOGICALTYPE_FIELD_LENGTH = new HashMap<>();
+        LOGICALTYPE_FIELD_LENGTH.put(LogicalTypeAnnotation.uuidType(), 16);
+        LOGICALTYPE_FIELD_LENGTH.put(LogicalTypeAnnotation.intervalType(), 12);
         LOGICALTYPE_RECORDER_MAPPING = new HashMap<>();
         LOGICALTYPE_RECORDER_MAPPING.put(LogicalTypeAnnotation.uuidType(), FieldRecorder.UUID);
         LOGICALTYPE_RECORDER_MAPPING.put(LogicalTypeAnnotation.jsonType(), FieldRecorder.STRING);
         LOGICALTYPE_RECORDER_MAPPING.put(LogicalTypeAnnotation.bsonType(), FieldRecorder.BSON);
+        LOGICALTYPE_RECORDER_MAPPING.put(LogicalTypeAnnotation.intervalType(), FieldRecorder.INTERVAL);
     }
 
     public TablesawWriteSupport(final Table table) {
@@ -251,12 +284,21 @@ public class TablesawWriteSupport extends WriteSupport<Row> {
     }
 
     private Type createType(final Column<?> column) {
-        final ColumnType type = column.type();
+        final ColumnType columnType = column.type();
         final String name = column.name();
-        return Types
-            .optional(LOGICALTYPE_MAPPING.getOrDefault(typeMap.get(name), PRIMITIVE_MAPPING.get(type)))
-            .as(typeMap.getOrDefault(name, ANNOTATION_MAPPING.get(type)))
-            .named(name);
+        final PrimitiveTypeName primitiveType = LOGICALTYPE_MAPPING.getOrDefault(
+            typeMap.get(name), PRIMITIVE_MAPPING.get(columnType));
+        final PrimitiveBuilder<PrimitiveType> parquetType = Types
+            .optional(primitiveType);
+        final LogicalTypeAnnotation logicalType = typeMap.getOrDefault(name, ANNOTATION_MAPPING.get(columnType));
+        // All FIXED_LEN_BYTE_ARRAY columns must have a logical type and a length entry
+        if(primitiveType == PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY) {
+            parquetType.length(LOGICALTYPE_FIELD_LENGTH.get(logicalType));
+        }
+        if(logicalType != null) {
+            parquetType.as(logicalType);
+        }
+        return parquetType.named(name);
     }
 
     private FieldRecorder[] internalCreateRecorders(final Table table) {

--- a/src/main/java/net/tlabs/tablesaw/parquet/TablesawWriteSupport.java
+++ b/src/main/java/net/tlabs/tablesaw/parquet/TablesawWriteSupport.java
@@ -37,6 +37,11 @@ import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 import org.apache.parquet.schema.Type;
 import org.apache.parquet.schema.Types;
+import org.bson.BsonBinaryWriter;
+import org.bson.Document;
+import org.bson.codecs.DocumentCodec;
+import org.bson.codecs.EncoderContext;
+import org.bson.io.BasicOutputBuffer;
 
 import tech.tablesaw.api.ColumnType;
 import tech.tablesaw.api.Row;
@@ -107,6 +112,19 @@ public class TablesawWriteSupport extends WriteSupport<Row> {
                     .putLong(uuid.getLeastSignificantBits())
                     .rewind();
                 recordConsumer.addBinary(Binary.fromReusedByteBuffer(buffer));
+            }
+        },
+        BSON(ColumnType.STRING) {
+            private final DocumentCodec codec = new DocumentCodec();
+            private final BasicOutputBuffer buffer = new BasicOutputBuffer();
+            private final EncoderContext encoderContext = EncoderContext.builder().build();
+            @Override
+            void recordValue(final RecordConsumer recordConsumer, final TableProxy tableProxy, 
+                    final int colIndex, final int rowNumber) {
+                final Document doc = Document.parse(tableProxy.getString(colIndex, rowNumber));
+                buffer.truncateToPosition(0);
+                codec.encode(new BsonBinaryWriter(buffer), doc, encoderContext);
+                recordConsumer.addBinary(Binary.fromReusedByteArray(buffer.getInternalBuffer()));
             }
         },
         LOCAL_DATE(ColumnType.LOCAL_DATE) {
@@ -204,9 +222,11 @@ public class TablesawWriteSupport extends WriteSupport<Row> {
         LOGICALTYPE_MAPPING = new HashMap<>();
         LOGICALTYPE_MAPPING.put(LogicalTypeAnnotation.uuidType(), PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY);
         LOGICALTYPE_MAPPING.put(LogicalTypeAnnotation.jsonType(), PrimitiveTypeName.BINARY);
+        LOGICALTYPE_MAPPING.put(LogicalTypeAnnotation.bsonType(), PrimitiveTypeName.BINARY);
         LOGICALTYPE_RECORDER_MAPPING = new HashMap<>();
         LOGICALTYPE_RECORDER_MAPPING.put(LogicalTypeAnnotation.uuidType(), FieldRecorder.UUID);
         LOGICALTYPE_RECORDER_MAPPING.put(LogicalTypeAnnotation.jsonType(), FieldRecorder.STRING);
+        LOGICALTYPE_RECORDER_MAPPING.put(LogicalTypeAnnotation.bsonType(), FieldRecorder.BSON);
     }
 
     public TablesawWriteSupport(final Table table) {

--- a/src/main/java/net/tlabs/tablesaw/parquet/TablesawWriteSupport.java
+++ b/src/main/java/net/tlabs/tablesaw/parquet/TablesawWriteSupport.java
@@ -20,9 +20,13 @@ package net.tlabs.tablesaw.parquet;
  * #L%
  */
 
+import java.nio.ByteBuffer;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.UUID;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.hadoop.api.WriteSupport;
 import org.apache.parquet.io.api.Binary;
@@ -91,6 +95,19 @@ public class TablesawWriteSupport extends WriteSupport<Row> {
                 recordConsumer.addBinary(Binary.fromString(tableProxy.getString(colIndex, rowNumber)));
             }
         },
+        UUID(ColumnType.STRING) {
+            private final ByteBuffer buffer = ByteBuffer.allocateDirect(16);
+            @Override
+            void recordValue(RecordConsumer recordConsumer, TableProxy tableProxy, int colIndex, int rowNumber) {
+                final UUID uuid = java.util.UUID.fromString(tableProxy.getString(colIndex, rowNumber));
+                buffer
+                    .clear()
+                    .putLong(uuid.getMostSignificantBits())
+                    .putLong(uuid.getLeastSignificantBits())
+                    .rewind();
+                recordConsumer.addBinary(Binary.fromReusedByteBuffer(buffer));
+            }
+        },
         LOCAL_DATE(ColumnType.LOCAL_DATE) {
             @Override
             void recordValue(final RecordConsumer recordConsumer, final TableProxy tableProxy,
@@ -128,6 +145,13 @@ public class TablesawWriteSupport extends WriteSupport<Row> {
         
         abstract void recordValue(final RecordConsumer recordConsumer, final TableProxy tableProxy,
                 final int colIndex, final int rowNumber);
+
+        void validate(final ColumnType type) {
+            if(!this.columnType.equals(type)) {
+                throw new IllegalArgumentException(this.name() + " recorder needs a " 
+                        + columnType.name() + " column, not a " + type.name() + " column");
+            }
+        }
         
     }
     
@@ -135,11 +159,14 @@ public class TablesawWriteSupport extends WriteSupport<Row> {
     private static final Map<ColumnType, PrimitiveTypeName> PRIMITIVE_MAPPING;
     private static final Map<ColumnType, LogicalTypeAnnotation> ANNOTATION_MAPPING;
     private static final Map<ColumnType, FieldRecorder> RECORDER_MAPPING;
+    private static final Map<LogicalTypeAnnotation, FieldRecorder> LOGICALTYPE_RECORDER_MAPPING;
+    private static final Map<LogicalTypeAnnotation, PrimitiveTypeName> LOGICALTYPE_MAPPING;
     private final TableProxy proxy;
     private final MessageType schema;
     private final int nbfields;
     private RecordConsumer recordConsumer;
-    private FieldRecorder[] fieldRecorders;
+    private final FieldRecorder[] fieldRecorders;
+    private final Map<String, LogicalTypeAnnotation> typeMap;
 
     static {
         PRIMITIVE_MAPPING = new HashMap<>();
@@ -173,41 +200,56 @@ public class TablesawWriteSupport extends WriteSupport<Row> {
         RECORDER_MAPPING.put(ColumnType.LOCAL_DATE_TIME, FieldRecorder.LOCAL_DATE_TIME);
         RECORDER_MAPPING.put(ColumnType.INSTANT, FieldRecorder.INSTANT);
         RECORDER_MAPPING.put(ColumnType.STRING, FieldRecorder.STRING);
+        LOGICALTYPE_MAPPING = new HashMap<>();
+        LOGICALTYPE_MAPPING.put(LogicalTypeAnnotation.uuidType(), PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY);
+        LOGICALTYPE_RECORDER_MAPPING = new HashMap<>();
+        LOGICALTYPE_RECORDER_MAPPING.put(LogicalTypeAnnotation.uuidType(), FieldRecorder.UUID);
     }
 
     public TablesawWriteSupport(final Table table) {
+        this(table, Collections.emptyMap());
+    }
+
+    public TablesawWriteSupport(final Table table, final Map<String, LogicalTypeAnnotation> typeMap) {
         super();
         this.proxy = new TableProxy(table);
+        this.typeMap = typeMap;
         this.schema = internalCreateSchema(table);
         this.nbfields = schema.getFieldCount();
         this.fieldRecorders = internalCreateRecorders(table);
     }
 
-    private static FieldRecorder[] internalCreateRecorders(final Table table) {
+    private MessageType internalCreateSchema(final Table table) {
+        final String tableName = table.name();
+        return new MessageType(tableName == null ? "message" : tableName,
+            table.columns().stream()
+            .map(this::createType)
+            .collect(Collectors.toList()));
+    }
+
+    private Type createType(final Column<?> column) {
+        final ColumnType type = column.type();
+        final String name = column.name();
+        return Types
+            .optional(LOGICALTYPE_MAPPING.getOrDefault(typeMap.getOrDefault(column.name(), null), PRIMITIVE_MAPPING.get(type)))
+            .as(typeMap.getOrDefault(name, ANNOTATION_MAPPING.get(type)))
+            .named(name);
+    }
+
+    private FieldRecorder[] internalCreateRecorders(final Table table) {
         return table.columns().stream()
-            .map(Column::type)
-            .map(RECORDER_MAPPING::get)
+            .map(this::createRecorder)
             .collect(Collectors.toList())
             .toArray(new FieldRecorder[0]);
     }
     
-    public static MessageType createSchema(final Table table) {
-        return internalCreateSchema(table);
+    private FieldRecorder createRecorder(final Column<?> column) {
+        final FieldRecorder recorder = LOGICALTYPE_RECORDER_MAPPING
+            .getOrDefault(typeMap.getOrDefault(column.name(), null), RECORDER_MAPPING.get(column.type()));
+        recorder.validate(column.type());
+        return recorder;
     }
-
-    private static MessageType internalCreateSchema(final Table table) {
-        final String tableName = table.name();
-        return new MessageType(tableName == null ? "message" : tableName,
-            table.columns().stream()
-            .map(TablesawWriteSupport::createType)
-            .collect(Collectors.toList()));
-    }
-
-    private static Type createType(final Column<?> column) {
-        final ColumnType type = column.type();
-        return Types.optional(PRIMITIVE_MAPPING.get(type)).as(ANNOTATION_MAPPING.get(type)).named(column.name());
-    }
-
+    
     @SuppressWarnings("deprecation")
     @Override
     public WriteContext init(final Configuration configuration) {

--- a/src/test/java/net/tlabs/tablesaw/parquet/TestColumnTypeInitialization.java
+++ b/src/test/java/net/tlabs/tablesaw/parquet/TestColumnTypeInitialization.java
@@ -23,6 +23,7 @@ package net.tlabs.tablesaw.parquet;
 import java.io.File;
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import tech.tablesaw.api.DoubleColumn;
@@ -30,12 +31,19 @@ import tech.tablesaw.api.Table;
 
 class TestColumnTypeInitialization {
 
+    private static final String TEST_OUTPUT = "target/test/results/test.parquet";
+
+    @AfterEach
+    void cleanup() {
+        new File(TEST_OUTPUT).delete();
+    }
+    
     @Test
     void testColumnTypeNotInitializedBug() {
         //tech.tablesaw.api.ColumnType.values(); // Workaround
         Table table = Table.create("t").addColumns(DoubleColumn.create("c", 1, 2, 3));
-        new TablesawParquetWriter().write(table, TablesawParquetWriteOptions.builder("target/test/results/test.parquet").build());
-        assertTrue(new File("target/test/results/test.parquet").exists(), "File not written");
+        new TablesawParquetWriter().write(table, TablesawParquetWriteOptions.builder(TEST_OUTPUT).build());
+        assertTrue(new File(TEST_OUTPUT).exists(), "File not written");
     }
 
 }

--- a/src/test/java/net/tlabs/tablesaw/parquet/TestParquetWriter.java
+++ b/src/test/java/net/tlabs/tablesaw/parquet/TestParquetWriter.java
@@ -23,7 +23,9 @@ package net.tlabs.tablesaw.parquet;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -34,11 +36,19 @@ import java.util.List;
 import java.util.Map;
 
 import net.tlabs.tablesaw.parquet.TablesawParquetWriteOptions.CompressionCodec;
+import net.tlabs.tablesaw.parquet.TablesawParquetWriteOptions.LogicalType;
 
 import org.apache.parquet.crypto.AADPrefixVerifier;
 import org.apache.parquet.crypto.ParquetCipher;
 import org.apache.parquet.crypto.ParquetCryptoRuntimeException;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.io.LocalInputFile;
 import org.apache.parquet.io.ParquetDecodingException;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.UUIDLogicalTypeAnnotation;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+import org.apache.parquet.schema.Type;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import tech.tablesaw.api.BooleanColumn;
@@ -72,6 +82,7 @@ class TestParquetWriter {
     private static final File OUTPUT_FILE = new File(OUTPUT_FILE_NAME);
     private static final String CRC_FILE_NAME = "target/test/results/.out.parquet.crc";
     private static final File CRC_FILE = new File(CRC_FILE_NAME);
+    private static final String UUID_PARQUET = "target/test-classes/uuid.parquet";
 
     private static final TablesawParquetWriter PARQUET_WRITER = new TablesawParquetWriter();
     private static final TablesawParquetReader PARQUET_READER = new TablesawParquetReader();
@@ -619,4 +630,29 @@ class TestParquetWriter {
         final File checksumFile = new File(OUTPUT_FILE_NAME);
         assertTrue(checksumFile.exists(), "Error writing smaller group size");
     }
+    
+    @Test
+    void testUUIDLogicalType() throws IOException {
+        final UUIDLogicalTypeAnnotation uuidType = LogicalTypeAnnotation.uuidType();
+        final Table orig = PARQUET_READER.read(TablesawParquetReadOptions.builder(UUID_PARQUET).build());
+        final TablesawParquetWriteOptions options = TablesawParquetWriteOptions.builder(OUTPUT_FILE)
+            .withLogicalTypes(Map.of("uuid_req1", LogicalType.UUID)).build();
+        assertEquals(Map.of("uuid_req1", uuidType), options.getLogicalTypes());
+        PARQUET_WRITER.write(orig, options);
+        ParquetFileReader reader = ParquetFileReader.open(new LocalInputFile(Path.of(OUTPUT_FILE_NAME)));
+        final Type type = reader.getFileMetaData().getSchema().getType("uuid_req1");
+        assertTrue(type.isPrimitive());
+        final PrimitiveType primitiveType = type.asPrimitiveType();
+        assertEquals(PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY, primitiveType.getPrimitiveTypeName());
+        final LogicalTypeAnnotation logicalTypeAnnotation = type.getLogicalTypeAnnotation();
+        assertEquals(uuidType, logicalTypeAnnotation);
+    }
+
+    @Test
+    void testUUIDLogicalTypeWrongColumnType() {
+        final TablesawParquetWriteOptions options = TablesawParquetWriteOptions.builder(OUTPUT_FILE)
+            .withLogicalTypes(Map.of("bool_col", LogicalType.UUID)).build();
+        assertThrows(IllegalArgumentException.class, () -> PARQUET_WRITER.write(ALL_TYPE_PLAIN_TABLE, options));
+    }
+
 }

--- a/src/test/java/net/tlabs/tablesaw/parquet/TestParquetWriter.java
+++ b/src/test/java/net/tlabs/tablesaw/parquet/TestParquetWriter.java
@@ -134,15 +134,15 @@ class TestParquetWriter {
         for (int rowIndex = 0; rowIndex < numberOfRows; rowIndex++) {
             for (int columnIndex = 0; columnIndex < numberOfColumns; columnIndex++) {
                 assertEquals(expected.get(rowIndex, columnIndex), actual.get(rowIndex, columnIndex),
-                    header + " cells[" + rowIndex + ", " + columnIndex + "] do not match");
+                    header + " cell [" + rowIndex + ", " + columnIndex + "] does not match");
             }
         }
     }
     
     @AfterEach
     void cleanup() {
-//        OUTPUT_FILE.delete();
-//        CRC_FILE.delete();
+        OUTPUT_FILE.delete();
+        CRC_FILE.delete();
     }
 
     @Test
@@ -730,6 +730,40 @@ class TestParquetWriter {
         final Table orig = PARQUET_READER.read(TablesawParquetReadOptions.builder(PARQUET_TESTING_FOLDER + BSON_PARQUET).build());
         final TablesawParquetWriteOptions options = TablesawParquetWriteOptions.builder(OUTPUT_FILE)
             .withLogicalTypes(Map.of("bson_field", LogicalType.BSON)).build();
+        PARQUET_WRITER.write(orig, options);
+        final Table dest = PARQUET_READER.read(TablesawParquetReadOptions.builder(OUTPUT_FILE).build());
+        assertTableEquals(orig, dest, BSON_PARQUET);
+    }
+
+    @Test
+    void testIntervalLogicalTypeOption() {
+        final TablesawParquetWriteOptions options = TablesawParquetWriteOptions.builder(OUTPUT_FILE)
+            .withLogicalTypes(Map.of("interval", LogicalType.INTERVAL)).build();
+        assertEquals(Map.of("interval", LogicalTypeAnnotation.intervalType()), options.getLogicalTypes());
+    }
+
+    @Test
+    void testIntervalLogicalTypeWriting() throws IOException {
+        final Table orig = Table.create().addColumns(StringColumn.create("interval",
+            "P6M4DT12H30M5S", "P23DT23H", "P1M", "PT1M"));
+        final TablesawParquetWriteOptions options = TablesawParquetWriteOptions.builder(OUTPUT_FILE)
+            .withLogicalTypes(Map.of("interval", LogicalType.INTERVAL)).build();
+        PARQUET_WRITER.write(orig, options);
+        ParquetFileReader reader = ParquetFileReader.open(new LocalInputFile(Path.of(OUTPUT_FILE_NAME)));
+        final Type type = reader.getFileMetaData().getSchema().getType("interval");
+        assertTrue(type.isPrimitive());
+        final PrimitiveType primitiveType = type.asPrimitiveType();
+        assertEquals(PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY, primitiveType.getPrimitiveTypeName());
+        final LogicalTypeAnnotation logicalTypeAnnotation = type.getLogicalTypeAnnotation();
+        assertEquals(LogicalTypeAnnotation.intervalType(), logicalTypeAnnotation);
+    }
+
+    @Test
+    void testIntervalReloading() {
+        final Table orig = Table.create().addColumns(StringColumn.create("interval",
+            "P6M4DT12H30M5S", "P0D", "P1M", "PT1M", "P-6MT-6H", "PT-6M", "P-6D", "PT1M1.001S"));
+        final TablesawParquetWriteOptions options = TablesawParquetWriteOptions.builder(OUTPUT_FILE)
+            .withLogicalTypes(Map.of("interval", LogicalType.INTERVAL)).build();
         PARQUET_WRITER.write(orig, options);
         final Table dest = PARQUET_READER.read(TablesawParquetReadOptions.builder(OUTPUT_FILE).build());
         assertTableEquals(orig, dest, BSON_PARQUET);

--- a/src/test/java/net/tlabs/tablesaw/parquet/TestParquetWriter.java
+++ b/src/test/java/net/tlabs/tablesaw/parquet/TestParquetWriter.java
@@ -83,6 +83,7 @@ class TestParquetWriter {
     private static final File CRC_FILE = new File(CRC_FILE_NAME);
     private static final String UUID_PARQUET = "target/test-classes/uuid.parquet";
     private static final String JSON_PARQUET = "json.parquet";
+    private static final String BSON_PARQUET = "bson.parquet";
 
     private static final TablesawParquetWriter PARQUET_WRITER = new TablesawParquetWriter();
     private static final TablesawParquetReader PARQUET_READER = new TablesawParquetReader();
@@ -140,8 +141,8 @@ class TestParquetWriter {
     
     @AfterEach
     void cleanup() {
-        OUTPUT_FILE.delete();
-        CRC_FILE.delete();
+//        OUTPUT_FILE.delete();
+//        CRC_FILE.delete();
     }
 
     @Test
@@ -699,6 +700,38 @@ class TestParquetWriter {
             .withLogicalTypes(Map.of("json_field", LogicalType.JSON)).build();
         PARQUET_WRITER.write(orig, options);
         final Table dest = PARQUET_READER.read(TablesawParquetReadOptions.builder(OUTPUT_FILE).build());
-        assertTableEquals(orig, dest, UUID_PARQUET);
+        assertTableEquals(orig, dest, JSON_PARQUET);
+    }
+
+    @Test
+    void testBsonLogicalTypeOption() {
+        final TablesawParquetWriteOptions options = TablesawParquetWriteOptions.builder(OUTPUT_FILE)
+            .withLogicalTypes(Map.of("bson", LogicalType.BSON)).build();
+        assertEquals(Map.of("bson", LogicalTypeAnnotation.bsonType()), options.getLogicalTypes());
+    }
+
+    @Test
+    void testBsonLogicalTypeWriting() throws IOException {
+        final Table orig = PARQUET_READER.read(TablesawParquetReadOptions.builder(PARQUET_TESTING_FOLDER + BSON_PARQUET).build());
+        final TablesawParquetWriteOptions options = TablesawParquetWriteOptions.builder(OUTPUT_FILE)
+            .withLogicalTypes(Map.of("bson_field", LogicalType.BSON)).build();
+        PARQUET_WRITER.write(orig, options);
+        ParquetFileReader reader = ParquetFileReader.open(new LocalInputFile(Path.of(OUTPUT_FILE_NAME)));
+        final Type type = reader.getFileMetaData().getSchema().getType("bson_field");
+        assertTrue(type.isPrimitive());
+        final PrimitiveType primitiveType = type.asPrimitiveType();
+        assertEquals(PrimitiveTypeName.BINARY, primitiveType.getPrimitiveTypeName());
+        final LogicalTypeAnnotation logicalTypeAnnotation = type.getLogicalTypeAnnotation();
+        assertEquals(LogicalTypeAnnotation.bsonType(), logicalTypeAnnotation);
+    }
+
+    @Test
+    void testBsonReloading() {
+        final Table orig = PARQUET_READER.read(TablesawParquetReadOptions.builder(PARQUET_TESTING_FOLDER + BSON_PARQUET).build());
+        final TablesawParquetWriteOptions options = TablesawParquetWriteOptions.builder(OUTPUT_FILE)
+            .withLogicalTypes(Map.of("bson_field", LogicalType.BSON)).build();
+        PARQUET_WRITER.write(orig, options);
+        final Table dest = PARQUET_READER.read(TablesawParquetReadOptions.builder(OUTPUT_FILE).build());
+        assertTableEquals(orig, dest, BSON_PARQUET);
     }
 }

--- a/src/test/java/net/tlabs/tablesaw/parquet/TestParquetWriter.java
+++ b/src/test/java/net/tlabs/tablesaw/parquet/TestParquetWriter.java
@@ -45,7 +45,6 @@ import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.io.LocalInputFile;
 import org.apache.parquet.io.ParquetDecodingException;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
-import org.apache.parquet.schema.LogicalTypeAnnotation.UUIDLogicalTypeAnnotation;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 import org.apache.parquet.schema.Type;
@@ -83,6 +82,7 @@ class TestParquetWriter {
     private static final String CRC_FILE_NAME = "target/test/results/.out.parquet.crc";
     private static final File CRC_FILE = new File(CRC_FILE_NAME);
     private static final String UUID_PARQUET = "target/test-classes/uuid.parquet";
+    private static final String JSON_PARQUET = "json.parquet";
 
     private static final TablesawParquetWriter PARQUET_WRITER = new TablesawParquetWriter();
     private static final TablesawParquetReader PARQUET_READER = new TablesawParquetReader();
@@ -627,17 +627,22 @@ class TestParquetWriter {
             .withRowGroupSize(2l * 1024 * 1024).build();
         assertEquals(2l * 1024 * 1024, options.getRowGroupSize());
         PARQUET_WRITER.write(orig, options);
-        final File checksumFile = new File(OUTPUT_FILE_NAME);
-        assertTrue(checksumFile.exists(), "Error writing smaller group size");
+        final File outputFile = new File(OUTPUT_FILE_NAME);
+        assertTrue(outputFile.exists(), "Error writing smaller group size");
     }
-    
+
     @Test
-    void testUUIDLogicalType() throws IOException {
-        final UUIDLogicalTypeAnnotation uuidType = LogicalTypeAnnotation.uuidType();
+    void testUUIDLogicalTypeOption() {
+        final TablesawParquetWriteOptions options = TablesawParquetWriteOptions.builder(OUTPUT_FILE)
+            .withLogicalTypes(Map.of("uuid_req1", LogicalType.UUID)).build();
+        assertEquals(Map.of("uuid_req1", LogicalTypeAnnotation.uuidType()), options.getLogicalTypes());
+    }
+
+    @Test
+    void testUUIDLogicalTypeWriting() throws IOException {
         final Table orig = PARQUET_READER.read(TablesawParquetReadOptions.builder(UUID_PARQUET).build());
         final TablesawParquetWriteOptions options = TablesawParquetWriteOptions.builder(OUTPUT_FILE)
             .withLogicalTypes(Map.of("uuid_req1", LogicalType.UUID)).build();
-        assertEquals(Map.of("uuid_req1", uuidType), options.getLogicalTypes());
         PARQUET_WRITER.write(orig, options);
         ParquetFileReader reader = ParquetFileReader.open(new LocalInputFile(Path.of(OUTPUT_FILE_NAME)));
         final Type type = reader.getFileMetaData().getSchema().getType("uuid_req1");
@@ -645,7 +650,17 @@ class TestParquetWriter {
         final PrimitiveType primitiveType = type.asPrimitiveType();
         assertEquals(PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY, primitiveType.getPrimitiveTypeName());
         final LogicalTypeAnnotation logicalTypeAnnotation = type.getLogicalTypeAnnotation();
-        assertEquals(uuidType, logicalTypeAnnotation);
+        assertEquals(LogicalTypeAnnotation.uuidType(), logicalTypeAnnotation);
+    }
+    
+    @Test
+    void testUUIDReloading() {
+        final Table orig = PARQUET_READER.read(TablesawParquetReadOptions.builder(UUID_PARQUET).build());
+        final TablesawParquetWriteOptions options = TablesawParquetWriteOptions.builder(OUTPUT_FILE)
+            .withLogicalTypes(Map.of("uuid_req1", LogicalType.UUID)).build();
+        PARQUET_WRITER.write(orig, options);
+        final Table dest = PARQUET_READER.read(TablesawParquetReadOptions.builder(OUTPUT_FILE).build());
+        assertTableEquals(orig, dest, UUID_PARQUET);
     }
 
     @Test
@@ -655,4 +670,35 @@ class TestParquetWriter {
         assertThrows(IllegalArgumentException.class, () -> PARQUET_WRITER.write(ALL_TYPE_PLAIN_TABLE, options));
     }
 
+    @Test
+    void testJsonLogicalTypeOption() {
+        final TablesawParquetWriteOptions options = TablesawParquetWriteOptions.builder(OUTPUT_FILE)
+            .withLogicalTypes(Map.of("json", LogicalType.JSON)).build();
+        assertEquals(Map.of("json", LogicalTypeAnnotation.jsonType()), options.getLogicalTypes());
+    }
+
+    @Test
+    void testJsonLogicalTypeWriting() throws IOException {
+        final Table orig = PARQUET_READER.read(TablesawParquetReadOptions.builder(PARQUET_TESTING_FOLDER + JSON_PARQUET).build());
+        final TablesawParquetWriteOptions options = TablesawParquetWriteOptions.builder(OUTPUT_FILE)
+            .withLogicalTypes(Map.of("json_field", LogicalType.JSON)).build();
+        PARQUET_WRITER.write(orig, options);
+        ParquetFileReader reader = ParquetFileReader.open(new LocalInputFile(Path.of(OUTPUT_FILE_NAME)));
+        final Type type = reader.getFileMetaData().getSchema().getType("json_field");
+        assertTrue(type.isPrimitive());
+        final PrimitiveType primitiveType = type.asPrimitiveType();
+        assertEquals(PrimitiveTypeName.BINARY, primitiveType.getPrimitiveTypeName());
+        final LogicalTypeAnnotation logicalTypeAnnotation = type.getLogicalTypeAnnotation();
+        assertEquals(LogicalTypeAnnotation.jsonType(), logicalTypeAnnotation);
+    }
+
+    @Test
+    void testJsonReloading() {
+        final Table orig = PARQUET_READER.read(TablesawParquetReadOptions.builder(PARQUET_TESTING_FOLDER + JSON_PARQUET).build());
+        final TablesawParquetWriteOptions options = TablesawParquetWriteOptions.builder(OUTPUT_FILE)
+            .withLogicalTypes(Map.of("json_field", LogicalType.JSON)).build();
+        PARQUET_WRITER.write(orig, options);
+        final Table dest = PARQUET_READER.read(TablesawParquetReadOptions.builder(OUTPUT_FILE).build());
+        assertTableEquals(orig, dest, UUID_PARQUET);
+    }
 }


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

- Added the `withLogicalTypes` writer option to set different parquet logical types when writing StringColumns
- Supported types are UUID, INTERVAL, JSON, and BSON. No validation is made on the column values before writing.
- Improved parquet INTERVAL type string representation in tablesaw to conform to ISO 8601

## Testing

Yes
