### PR TITLE
Add Float16 read/write support

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Annotated [parquet logical types](https://github.com/apache/parquet-format/blob/
 | Signed Integers | ShortColumn or IntColumn or LongColumn | ShortColumn only with the *minimizeColumnSizes* option |
 | Unsigned Integers  | ShortColumn or IntColumn or LongColumn | ShortColumn only with the *minimizeColumnSizes* option |
 | DECIMAL | DoubleColumn |  |
+| FLOAT16 | DoubleColumn (default) or FloatColumn |  Managed by the *minimizeColumnSizes* option  |
 | DATE | DateColumn |  |
 | TIME | TimeColumn |  |
 | TIMESTAMP | DateTimeColumn or InstantColumn | Timestamps normalized to UTC are converted to Instant, others as LocalDateTime |

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Note that the `ColumnType.SKIP` column type can be used with these options to fi
 | ShortColumn | INT32 (Integer: 16 bits, signed)|  |
 | IntColumn | INT32 |  |
 | LongColumn | INT64 |  |
-| FloatColumn | FLOAT |  |
+| FloatColumn | FLOAT |  Can be set to FLOAT16 using the *withLogicalTypes* option (since v0.16)  |
 | DoubleColumn | DOUBLE |  |
 | StringColumn | BINARY (STRING) |  Can be configured by the *withLogicalTypes* option (since v0.16, see below)  |
 | TimeColumn | INT32 (TIME: MILLIS, not UTC) | *Changed in v0.11.0, was INT64 (TIME: NANOS, not UTC) before* |

--- a/src/main/java/net/tlabs/tablesaw/parquet/TablesawParquetWriteOptions.java
+++ b/src/main/java/net/tlabs/tablesaw/parquet/TablesawParquetWriteOptions.java
@@ -51,7 +51,8 @@ public class TablesawParquetWriteOptions extends WriteOptions {
         UUID(LogicalTypeAnnotation.uuidType()),
         JSON(LogicalTypeAnnotation.jsonType()),
         BSON(LogicalTypeAnnotation.bsonType()),
-        INTERVAL(LogicalTypeAnnotation.intervalType());
+        INTERVAL(LogicalTypeAnnotation.intervalType()),
+        FLOAT16(LogicalTypeAnnotation.float16Type());
         
         final LogicalTypeAnnotation logicalTypeAnnotation;
         

--- a/src/main/java/net/tlabs/tablesaw/parquet/TablesawReadSupport.java
+++ b/src/main/java/net/tlabs/tablesaw/parquet/TablesawReadSupport.java
@@ -36,6 +36,7 @@ import org.apache.parquet.schema.LogicalTypeAnnotation.BsonLogicalTypeAnnotation
 import org.apache.parquet.schema.LogicalTypeAnnotation.DateLogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.DecimalLogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.EnumLogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.Float16LogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.GeographyLogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.GeometryLogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.IntLogicalTypeAnnotation;
@@ -263,12 +264,16 @@ public class TablesawReadSupport extends ReadSupport<Row> {
         });
     }
 
-    private static Optional<Column<?>> annotatedFixedLenBinaryColumn(final LogicalTypeAnnotation annotation,
+    private Optional<Column<?>> annotatedFixedLenBinaryColumn(final LogicalTypeAnnotation annotation,
             final String fieldName) {
         return annotation.accept(new LogicalTypeAnnotationVisitor<Column<?>>() {
             @Override
             public Optional<Column<?>> visit(final DecimalLogicalTypeAnnotation decimalLogicalType) {
                 return Optional.of(DoubleColumn.create(fieldName));
+            }
+            @Override
+            public Optional<Column<?>> visit(final Float16LogicalTypeAnnotation float16LogicalType) {
+                return Optional.of(options.isFloatColumnTypeUsed() ? FloatColumn.create(fieldName) : DoubleColumn.create(fieldName));
             }
         });
     }

--- a/src/main/java/net/tlabs/tablesaw/parquet/TablesawRecordConverter.java
+++ b/src/main/java/net/tlabs/tablesaw/parquet/TablesawRecordConverter.java
@@ -44,11 +44,13 @@ import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.io.api.Converter;
 import org.apache.parquet.io.api.GroupConverter;
 import org.apache.parquet.io.api.PrimitiveConverter;
+import org.apache.parquet.schema.Float16Util;
 import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.BsonLogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.DecimalLogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.EnumLogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.Float16LogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.GeographyLogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.GeometryLogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.IntervalLogicalTypeAnnotation;
@@ -239,32 +241,32 @@ public class TablesawRecordConverter extends GroupConverter {
         }
 
         @Override
-        public void addBinary(Binary value) {
+        public void addBinary(final Binary value) {
             addRepeatedValue(value.toStringUsingUTF8());
         }
 
         @Override
-        public void addBoolean(boolean value) {
+        public void addBoolean(final boolean value) {
             addRepeatedValue(Boolean.toString(value));
         }
 
         @Override
-        public void addDouble(double value) {
+        public void addDouble(final double value) {
             addRepeatedValue(Double.toString(value));
         }
 
         @Override
-        public void addFloat(float value) {
+        public void addFloat(final float value) {
             addRepeatedValue(Float.toString(value));
         }
 
         @Override
-        public void addInt(int value) {
+        public void addInt(final int value) {
             addRepeatedValue(Integer.toString(value));
         }
 
         @Override
-        public void addLong(long value) {
+        public void addLong(final long value) {
             addRepeatedValue(Long.toString(value));
         }
 
@@ -294,7 +296,7 @@ public class TablesawRecordConverter extends GroupConverter {
         }
 
         @Override
-        public void addBinary(Binary value) {
+        public void addBinary(final Binary value) {
             String valueStr = BINARY_INVALID;
             try {
                 final Geometry geometry = reader.read(value.getBytesUnsafe());
@@ -391,6 +393,10 @@ public class TablesawRecordConverter extends GroupConverter {
                 @Override
                 public void addFloat(final float value) {
                     proxy.appendFloat(colIndex, value);
+                }
+                @Override
+                public void addBinary(final Binary value) {
+                    proxy.appendFloat(colIndex, Float16Util.toFloat(value));
                 }
             };
         }
@@ -533,7 +539,7 @@ public class TablesawRecordConverter extends GroupConverter {
             }
             
             @Override
-            public Optional<Converter> visit(UUIDLogicalTypeAnnotation uuidLogicalType) {
+            public Optional<Converter> visit(final UUIDLogicalTypeAnnotation uuidLogicalType) {
                 return Optional.of(new PrimitiveConverter() {
                     @Override
                     public void addBinary(final Binary value) {
@@ -547,22 +553,22 @@ public class TablesawRecordConverter extends GroupConverter {
             }
 
             @Override
-            public Optional<Converter> visit(GeometryLogicalTypeAnnotation geometryLogicalType) {
+            public Optional<Converter> visit(final GeometryLogicalTypeAnnotation geometryLogicalType) {
                 return Optional.of(new GeospatialPrimitiveConverter(colIndex));
             }
             
             @Override
-            public Optional<Converter> visit(GeographyLogicalTypeAnnotation geographyLogicalType) {
+            public Optional<Converter> visit(final GeographyLogicalTypeAnnotation geographyLogicalType) {
                 return Optional.of(new GeospatialPrimitiveConverter(colIndex));
             }
 
             @Override
-            public Optional<Converter> visit(JsonLogicalTypeAnnotation jsonLogicalType) {
+            public Optional<Converter> visit(final JsonLogicalTypeAnnotation jsonLogicalType) {
                 return Optional.of(new StringPrimitiveConverter(colIndex));
             }
 
             @Override
-            public Optional<Converter> visit(BsonLogicalTypeAnnotation bsonLogicalType) {
+            public Optional<Converter> visit(final BsonLogicalTypeAnnotation bsonLogicalType) {
                 return Optional.of(new PrimitiveConverter() {
                     private final DecoderContext context = DecoderContext.builder().build();
                     private final JsonWriterSettings settings = JsonWriterSettings.builder().build();
@@ -587,6 +593,15 @@ public class TablesawRecordConverter extends GroupConverter {
                     public void addBinary(final Binary value) {
                         final BigDecimal bigd = new BigDecimal(new BigInteger(value.getBytes()), decimalLogicalType.getScale());
                         proxy.appendDouble(colIndex, bigd.doubleValue());
+                    }
+                });
+            }
+            @Override
+            public Optional<Converter> visit(final Float16LogicalTypeAnnotation float16LogicalType) {
+                return Optional.of(new PrimitiveConverter() {
+                    @Override
+                    public void addBinary(final Binary value) {
+                        proxy.appendDouble(colIndex, Float16Util.toFloat(value));
                     }
                 });
             }

--- a/src/main/java/net/tlabs/tablesaw/parquet/TablesawWriteSupport.java
+++ b/src/main/java/net/tlabs/tablesaw/parquet/TablesawWriteSupport.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.hadoop.api.WriteSupport;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.io.api.RecordConsumer;
+import org.apache.parquet.schema.Float16Util;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.TimeUnit;
 import org.apache.parquet.schema.MessageType;
@@ -96,6 +97,18 @@ public class TablesawWriteSupport extends WriteSupport<Row> {
             void recordValue(final RecordConsumer recordConsumer, final TableProxy tableProxy,
                     final int colIndex, final int rowNumber) {
                 recordConsumer.addDouble(tableProxy.getDouble(colIndex, rowNumber));
+            }
+        },
+        FLOAT16 (ColumnType.FLOAT) {
+            private final ByteBuffer buffer = ByteBuffer.allocateDirect(2).order(ByteOrder.LITTLE_ENDIAN);
+            @Override
+            void recordValue(final RecordConsumer recordConsumer, final TableProxy tableProxy, 
+                    final int colIndex, final int rowNumber) {
+                buffer
+                   .clear()
+                   .putShort(Float16Util.toFloat16(tableProxy.getFloat(colIndex, rowNumber)))
+                   .rewind();
+                recordConsumer.addBinary(Binary.fromReusedByteBuffer(buffer));
             }
         },
         STRING(ColumnType.STRING) {
@@ -254,14 +267,17 @@ public class TablesawWriteSupport extends WriteSupport<Row> {
         LOGICALTYPE_MAPPING.put(LogicalTypeAnnotation.jsonType(), PrimitiveTypeName.BINARY);
         LOGICALTYPE_MAPPING.put(LogicalTypeAnnotation.bsonType(), PrimitiveTypeName.BINARY);
         LOGICALTYPE_MAPPING.put(LogicalTypeAnnotation.intervalType(), PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY);
+        LOGICALTYPE_MAPPING.put(LogicalTypeAnnotation.float16Type(), PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY);
         LOGICALTYPE_FIELD_LENGTH = new HashMap<>();
         LOGICALTYPE_FIELD_LENGTH.put(LogicalTypeAnnotation.uuidType(), 16);
         LOGICALTYPE_FIELD_LENGTH.put(LogicalTypeAnnotation.intervalType(), 12);
+        LOGICALTYPE_FIELD_LENGTH.put(LogicalTypeAnnotation.float16Type(), 2);
         LOGICALTYPE_RECORDER_MAPPING = new HashMap<>();
         LOGICALTYPE_RECORDER_MAPPING.put(LogicalTypeAnnotation.uuidType(), FieldRecorder.UUID);
         LOGICALTYPE_RECORDER_MAPPING.put(LogicalTypeAnnotation.jsonType(), FieldRecorder.STRING);
         LOGICALTYPE_RECORDER_MAPPING.put(LogicalTypeAnnotation.bsonType(), FieldRecorder.BSON);
         LOGICALTYPE_RECORDER_MAPPING.put(LogicalTypeAnnotation.intervalType(), FieldRecorder.INTERVAL);
+        LOGICALTYPE_RECORDER_MAPPING.put(LogicalTypeAnnotation.float16Type(), FieldRecorder.FLOAT16);
     }
 
     public TablesawWriteSupport(final Table table) {

--- a/src/main/java/org/apache/parquet/schema/Float16Util.java
+++ b/src/main/java/org/apache/parquet/schema/Float16Util.java
@@ -1,0 +1,41 @@
+package org.apache.parquet.schema;
+
+/*-
+ * #%L
+ * Tablesaw-Parquet
+ * %%
+ * Copyright (C) 2020 - 2021 Tlabs-data
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import org.apache.parquet.io.api.Binary;
+
+/**
+ * Utility class with public static methods to expose Float16 package protected methods.
+ */
+public class Float16Util {
+
+    private Float16Util() {
+        super();
+    }
+    
+    public static float toFloat(final Binary b) {
+        return Float16.toFloat(b);
+    }
+    
+    public static short toFloat16(final float f) {
+        return Float16.toFloat16(f);
+    }
+}

--- a/src/test/java/net/tlabs/tablesaw/parquet/TestAllParquetTestingFiles.java
+++ b/src/test/java/net/tlabs/tablesaw/parquet/TestAllParquetTestingFiles.java
@@ -22,6 +22,7 @@ package net.tlabs.tablesaw.parquet;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -32,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -264,5 +266,16 @@ class TestAllParquetTestingFiles {
         final Table table = new TablesawParquetReader().read(optionBuilder.build());
         assertNotNull(table);
         assertEquals(1, table.columnCount(), "Variant column should be skipped");
+    }
+    
+    @Test
+    void testFloat16Reading() {
+        final Table orig = new TablesawParquetReader()
+            .read(TablesawParquetReadOptions.builder(PARQUET_TESTING_FOLDER + "float16_nonzeros_and_nans.parquet")
+            .minimizeColumnSizes()
+            .build());
+        assertEquals(ColumnType.FLOAT, orig.column(0).type());
+        assertTrue(orig.column(0).isMissing(0));
+        assertEquals(-2f, orig.floatColumn(0).getFloat(2));
     }
 }

--- a/src/test/java/net/tlabs/tablesaw/parquet/TestParquetWriter.java
+++ b/src/test/java/net/tlabs/tablesaw/parquet/TestParquetWriter.java
@@ -84,6 +84,7 @@ class TestParquetWriter {
     private static final String UUID_PARQUET = "target/test-classes/uuid.parquet";
     private static final String JSON_PARQUET = "json.parquet";
     private static final String BSON_PARQUET = "bson.parquet";
+    private static final String FLOAT16_PARQUET = "float16_nonzeros_and_nans.parquet";
 
     private static final TablesawParquetWriter PARQUET_WRITER = new TablesawParquetWriter();
     private static final TablesawParquetReader PARQUET_READER = new TablesawParquetReader();
@@ -767,5 +768,40 @@ class TestParquetWriter {
         PARQUET_WRITER.write(orig, options);
         final Table dest = PARQUET_READER.read(TablesawParquetReadOptions.builder(OUTPUT_FILE).build());
         assertTableEquals(orig, dest, BSON_PARQUET);
+    }
+
+    @Test
+    void testFloat16LogicalTypeOption() {
+        final TablesawParquetWriteOptions options = TablesawParquetWriteOptions.builder(OUTPUT_FILE)
+            .withLogicalTypes(Map.of("float", LogicalType.FLOAT16)).build();
+        assertEquals(Map.of("float", LogicalTypeAnnotation.float16Type()), options.getLogicalTypes());
+    }
+
+    @Test
+    void testFloat16LogicalTypeWriting() throws IOException {
+        final Table orig = PARQUET_READER.read(TablesawParquetReadOptions.builder(PARQUET_TESTING_FOLDER + FLOAT16_PARQUET)
+            .minimizeColumnSizes().build());
+        final TablesawParquetWriteOptions options = TablesawParquetWriteOptions.builder(OUTPUT_FILE)
+            .withLogicalTypes(Map.of("x", LogicalType.FLOAT16)).build();
+        PARQUET_WRITER.write(orig, options);
+        ParquetFileReader reader = ParquetFileReader.open(new LocalInputFile(Path.of(OUTPUT_FILE_NAME)));
+        final Type type = reader.getFileMetaData().getSchema().getType("x");
+        assertTrue(type.isPrimitive());
+        final PrimitiveType primitiveType = type.asPrimitiveType();
+        assertEquals(PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY, primitiveType.getPrimitiveTypeName());
+        final LogicalTypeAnnotation logicalTypeAnnotation = type.getLogicalTypeAnnotation();
+        assertEquals(LogicalTypeAnnotation.float16Type(), logicalTypeAnnotation);
+    }
+
+    @Test
+    void testFloat16Reloading() {
+        final Table orig = PARQUET_READER.read(TablesawParquetReadOptions.builder(PARQUET_TESTING_FOLDER + FLOAT16_PARQUET)
+            .minimizeColumnSizes().build());
+        final TablesawParquetWriteOptions options = TablesawParquetWriteOptions.builder(OUTPUT_FILE)
+            .withLogicalTypes(Map.of("x", LogicalType.FLOAT16)).build();
+        PARQUET_WRITER.write(orig, options);
+        final Table dest = PARQUET_READER.read(TablesawParquetReadOptions.builder(OUTPUT_FILE)
+            .minimizeColumnSizes().build());
+        assertTableEquals(orig, dest, FLOAT16_PARQUET);
     }
 }


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

- Added support to read FLOAT16 annotated parquet columns as Float/Double tablesaw columns
- Added support to write Float tablesaw columns to FLOAT16 annotated parquet columns

## Testing

Yes
