### PR TITLE
Write StringColumn as enum parquet type

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Note that the `ColumnType.SKIP` column type can be used with these options to fi
 
 Note that a tablesaw Table written to parquet and read back with default options will have Floats changed to Doubles and Shorts to Integers, as the *minimizeColumnSizes* reader option is false by default.
 
-Since v0.16, the `TablesawParquetWriteOptions.withLogicalTypes` method allows to specify a different Logical Type for StringColum. Available types are UUID, INTERVAL, JSON, and BSON. The column values must be valid representations of these types and no validation is done before converting data. If the option is used with another tablesaw column type than StringColumn, an `IllegalArgumentException` is raised when writing.
+Since v0.16, the `TablesawParquetWriteOptions.withLogicalTypes` method allows to specify a different Logical Type for StringColum. Available types are UUID, ENUM, INTERVAL, JSON, and BSON. The column values must be valid representations of these types and no validation is done before converting data. If the option is used with another tablesaw column type than StringColumn, an `IllegalArgumentException` is raised when writing.
 
 Note that parquet INTERVAL only supports Month and Days for the Period part, and the Duration part does not support Days and has MILLI precision only. Leading plus or minus signs are not supported, plus or minus signs on individual sections are supported.
 

--- a/src/main/java/net/tlabs/tablesaw/parquet/TablesawParquetWriteOptions.java
+++ b/src/main/java/net/tlabs/tablesaw/parquet/TablesawParquetWriteOptions.java
@@ -52,7 +52,8 @@ public class TablesawParquetWriteOptions extends WriteOptions {
         JSON(LogicalTypeAnnotation.jsonType()),
         BSON(LogicalTypeAnnotation.bsonType()),
         INTERVAL(LogicalTypeAnnotation.intervalType()),
-        FLOAT16(LogicalTypeAnnotation.float16Type());
+        FLOAT16(LogicalTypeAnnotation.float16Type()),
+        ENUM(LogicalTypeAnnotation.enumType());
         
         final LogicalTypeAnnotation logicalTypeAnnotation;
         

--- a/src/main/java/net/tlabs/tablesaw/parquet/TablesawRecordConverter.java
+++ b/src/main/java/net/tlabs/tablesaw/parquet/TablesawRecordConverter.java
@@ -87,7 +87,6 @@ public class TablesawRecordConverter extends GroupConverter {
     private static final String BINARY_INTERVAL_LENGTH_MESSAGE = "Must be 12 bytes";
     private static final String INTERVAL_PERIOD_DESIGNATOR = "P";
     private static final String INTERVAL_ZERO_STRING_REPRESENTATION = "P0D";
-    private static final int BINARY_UUID_LENGTH_VALUE = 16;
     private static final String BINARY_UUID_LENGTH_MESSAGE = "Must be 16 bytes";
 
     private final class DateTimePrimitiveConverter extends PrimitiveConverter {
@@ -543,7 +542,7 @@ public class TablesawRecordConverter extends GroupConverter {
                 return Optional.of(new PrimitiveConverter() {
                     @Override
                     public void addBinary(final Binary value) {
-                        Preconditions.checkArgument(value.length() == BINARY_UUID_LENGTH_VALUE,
+                        Preconditions.checkArgument(value.length() == UUIDLogicalTypeAnnotation.BYTES,
                             BINARY_UUID_LENGTH_MESSAGE);
                         final ByteBuffer buf = value.toByteBuffer();
                         buf.order(ByteOrder.BIG_ENDIAN);

--- a/src/main/java/net/tlabs/tablesaw/parquet/TablesawWriteSupport.java
+++ b/src/main/java/net/tlabs/tablesaw/parquet/TablesawWriteSupport.java
@@ -36,7 +36,9 @@ import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.io.api.RecordConsumer;
 import org.apache.parquet.schema.Float16Util;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.Float16LogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.TimeUnit;
+import org.apache.parquet.schema.LogicalTypeAnnotation.UUIDLogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
@@ -55,6 +57,8 @@ import tech.tablesaw.api.Table;
 import tech.tablesaw.columns.Column;
 
 public class TablesawWriteSupport extends WriteSupport<Row> {
+
+    private static final int INTERVAL_BYTE_LENGTH = 12;
 
     private enum FieldRecorder {
         BOOLEAN(ColumnType.BOOLEAN) {
@@ -100,7 +104,8 @@ public class TablesawWriteSupport extends WriteSupport<Row> {
             }
         },
         FLOAT16 (ColumnType.FLOAT) {
-            private final ByteBuffer buffer = ByteBuffer.allocateDirect(2).order(ByteOrder.LITTLE_ENDIAN);
+            private final ByteBuffer buffer = ByteBuffer.allocateDirect(Float16LogicalTypeAnnotation.BYTES)
+                .order(ByteOrder.LITTLE_ENDIAN);
             @Override
             void recordValue(final RecordConsumer recordConsumer, final TableProxy tableProxy, 
                     final int colIndex, final int rowNumber) {
@@ -119,7 +124,7 @@ public class TablesawWriteSupport extends WriteSupport<Row> {
             }
         },
         UUID(ColumnType.STRING) {
-            private final ByteBuffer buffer = ByteBuffer.allocateDirect(16);
+            private final ByteBuffer buffer = ByteBuffer.allocateDirect(UUIDLogicalTypeAnnotation.BYTES);
             @Override
             void recordValue(final RecordConsumer recordConsumer, final TableProxy tableProxy,
                     final int colIndex, final int rowNumber) {
@@ -174,7 +179,7 @@ public class TablesawWriteSupport extends WriteSupport<Row> {
             }
         },
         INTERVAL(ColumnType.STRING) {
-            private final ByteBuffer buffer = ByteBuffer.allocateDirect(12).order(ByteOrder.LITTLE_ENDIAN);
+            private final ByteBuffer buffer = ByteBuffer.allocateDirect(INTERVAL_BYTE_LENGTH).order(ByteOrder.LITTLE_ENDIAN);
             private final Period emptyPeriod = Period.of(0, 0, 0);
             private final Duration emptyDuration = Duration.ofMillis(0);
             @Override
@@ -269,9 +274,9 @@ public class TablesawWriteSupport extends WriteSupport<Row> {
         LOGICALTYPE_MAPPING.put(LogicalTypeAnnotation.intervalType(), PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY);
         LOGICALTYPE_MAPPING.put(LogicalTypeAnnotation.float16Type(), PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY);
         LOGICALTYPE_FIELD_LENGTH = new HashMap<>();
-        LOGICALTYPE_FIELD_LENGTH.put(LogicalTypeAnnotation.uuidType(), 16);
-        LOGICALTYPE_FIELD_LENGTH.put(LogicalTypeAnnotation.intervalType(), 12);
-        LOGICALTYPE_FIELD_LENGTH.put(LogicalTypeAnnotation.float16Type(), 2);
+        LOGICALTYPE_FIELD_LENGTH.put(LogicalTypeAnnotation.uuidType(), UUIDLogicalTypeAnnotation.BYTES);
+        LOGICALTYPE_FIELD_LENGTH.put(LogicalTypeAnnotation.intervalType(), INTERVAL_BYTE_LENGTH);
+        LOGICALTYPE_FIELD_LENGTH.put(LogicalTypeAnnotation.float16Type(), Float16LogicalTypeAnnotation.BYTES);
         LOGICALTYPE_RECORDER_MAPPING = new HashMap<>();
         LOGICALTYPE_RECORDER_MAPPING.put(LogicalTypeAnnotation.uuidType(), FieldRecorder.UUID);
         LOGICALTYPE_RECORDER_MAPPING.put(LogicalTypeAnnotation.jsonType(), FieldRecorder.STRING);

--- a/src/main/java/net/tlabs/tablesaw/parquet/TablesawWriteSupport.java
+++ b/src/main/java/net/tlabs/tablesaw/parquet/TablesawWriteSupport.java
@@ -269,6 +269,7 @@ public class TablesawWriteSupport extends WriteSupport<Row> {
         RECORDER_MAPPING.put(ColumnType.STRING, FieldRecorder.STRING);
         LOGICALTYPE_MAPPING = new HashMap<>();
         LOGICALTYPE_MAPPING.put(LogicalTypeAnnotation.uuidType(), PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY);
+        LOGICALTYPE_MAPPING.put(LogicalTypeAnnotation.enumType(), PrimitiveTypeName.BINARY);
         LOGICALTYPE_MAPPING.put(LogicalTypeAnnotation.jsonType(), PrimitiveTypeName.BINARY);
         LOGICALTYPE_MAPPING.put(LogicalTypeAnnotation.bsonType(), PrimitiveTypeName.BINARY);
         LOGICALTYPE_MAPPING.put(LogicalTypeAnnotation.intervalType(), PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY);
@@ -279,6 +280,7 @@ public class TablesawWriteSupport extends WriteSupport<Row> {
         LOGICALTYPE_FIELD_LENGTH.put(LogicalTypeAnnotation.float16Type(), Float16LogicalTypeAnnotation.BYTES);
         LOGICALTYPE_RECORDER_MAPPING = new HashMap<>();
         LOGICALTYPE_RECORDER_MAPPING.put(LogicalTypeAnnotation.uuidType(), FieldRecorder.UUID);
+        LOGICALTYPE_RECORDER_MAPPING.put(LogicalTypeAnnotation.enumType(), FieldRecorder.STRING);
         LOGICALTYPE_RECORDER_MAPPING.put(LogicalTypeAnnotation.jsonType(), FieldRecorder.STRING);
         LOGICALTYPE_RECORDER_MAPPING.put(LogicalTypeAnnotation.bsonType(), FieldRecorder.BSON);
         LOGICALTYPE_RECORDER_MAPPING.put(LogicalTypeAnnotation.intervalType(), FieldRecorder.INTERVAL);

--- a/src/test/java/net/tlabs/tablesaw/parquet/TestParquetWriter.java
+++ b/src/test/java/net/tlabs/tablesaw/parquet/TestParquetWriter.java
@@ -804,4 +804,38 @@ class TestParquetWriter {
             .minimizeColumnSizes().build());
         assertTableEquals(orig, dest, FLOAT16_PARQUET);
     }
+
+    @Test
+    void testEnumLogicalTypeOption() {
+        final TablesawParquetWriteOptions options = TablesawParquetWriteOptions.builder(OUTPUT_FILE)
+            .withLogicalTypes(Map.of("enum", LogicalType.ENUM)).build();
+        assertEquals(Map.of("enum", LogicalTypeAnnotation.enumType()), options.getLogicalTypes());
+    }
+
+    @Test
+    void testEnumLogicalTypeWriting() throws IOException {
+        final Table orig = Table.create().addColumns(StringColumn.create("enum",
+            "A", "B", "A", "D"));
+        final TablesawParquetWriteOptions options = TablesawParquetWriteOptions.builder(OUTPUT_FILE)
+            .withLogicalTypes(Map.of("enum", LogicalType.ENUM)).build();
+        PARQUET_WRITER.write(orig, options);
+        ParquetFileReader reader = ParquetFileReader.open(new LocalInputFile(Path.of(OUTPUT_FILE_NAME)));
+        final Type type = reader.getFileMetaData().getSchema().getType("enum");
+        assertTrue(type.isPrimitive());
+        final PrimitiveType primitiveType = type.asPrimitiveType();
+        assertEquals(PrimitiveTypeName.BINARY, primitiveType.getPrimitiveTypeName());
+        final LogicalTypeAnnotation logicalTypeAnnotation = type.getLogicalTypeAnnotation();
+        assertEquals(LogicalTypeAnnotation.enumType(), logicalTypeAnnotation);
+    }
+
+    @Test
+    void testEnumReloading() {
+        final Table orig = Table.create().addColumns(StringColumn.create("enum",
+            "A", "B", "A", "D"));
+        final TablesawParquetWriteOptions options = TablesawParquetWriteOptions.builder(OUTPUT_FILE)
+            .withLogicalTypes(Map.of("enum", LogicalType.ENUM)).build();
+        PARQUET_WRITER.write(orig, options);
+        final Table dest = PARQUET_READER.read(TablesawParquetReadOptions.builder(OUTPUT_FILE).build());
+        assertTableEquals(orig, dest, "ENUM TYPE");
+    }
 }


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Add support to write tablesaw StringColumn as an ENUM parquet column

## Testing

Yes
